### PR TITLE
Add repo removal command to CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,12 @@ across projects. Repos are stored in `repos.txt` and managed via
 `python -m axel.repo_manager`.
 
 - Keep the roadmap in `README.md` up to date as tasks progress.
-- Add new repos using the CLI or `axel.repo_manager.add_repo`.
+- Add new repos using the CLI or `axel.repo_manager.add_repo`, and remove them
+  with `axel.repo_manager.remove_repo` when needed.
 - Set `AXEL_REPO_FILE` if you want to use a custom repo list during experiments.
 - Run `flake8 axel tests` and `pytest --cov=axel --cov=tests` before committing.
 - Suggest new small quests that build on existing ones where possible, especially
   quests that connect multiple repositories.
+- Look for opportunities to integrate or document `token.place` clients across
+  the repositories listed in `repos.txt`.
 - Refer to `CONTRIBUTORS.md` for more detailed contribution instructions.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ axel helps organize short, medium and long term goals using chat, reasoning and 
 - [x] maintain a list of repos in `repos.txt`
 - [x] simple CLI for managing repos
 - [x] contributor guide
+- [x] remove repos from the list
 - [ ] fetch repos from the GitHub API
 - [ ] integrate LLM assistants to suggest quests across repos
+- [ ] integrate `token.place` clients across all repos
 
 ## usage
 
 1. Add a repo with `python -m axel.repo_manager add <url>` or edit `repos.txt`.
 2. View the list with `python -m axel.repo_manager list`.
-3. Run `flake8 axel tests` and `pytest --cov=axel --cov=tests` before committing.
-4. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
+3. Remove a repo with `python -m axel.repo_manager remove <url>`.
+4. Run `flake8 axel tests` and `pytest --cov=axel --cov=tests` before committing.
+5. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
 
 See `examples/` for a sample repo list.
 

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -29,6 +29,15 @@ def add_repo(url: str, path: Path = DEFAULT_REPO_FILE) -> List[str]:
     return repos
 
 
+def remove_repo(url: str, path: Path = DEFAULT_REPO_FILE) -> List[str]:
+    """Remove a repository URL from the list if present."""
+    repos = load_repos(path)
+    if url in repos:
+        repos.remove(url)
+        path.write_text("\n".join(repos))
+    return repos
+
+
 def list_repos(path: Path = DEFAULT_REPO_FILE) -> List[str]:
     """Return the list of repository URLs."""
     return load_repos(path)
@@ -48,12 +57,17 @@ def main(argv: List[str] | None = None) -> None:
     add_p = sub.add_parser("add", help="Add a repository URL")
     add_p.add_argument("url")
 
+    remove_p = sub.add_parser("remove", help="Remove a repository URL")
+    remove_p.add_argument("url")
+
     sub.add_parser("list", help="List repositories")
 
     args = parser.parse_args(argv)
 
     if args.cmd == "add":
         repos = add_repo(args.url, path=args.path)
+    elif args.cmd == "remove":
+        repos = remove_repo(args.url, path=args.path)
     else:
         repos = list_repos(path=args.path)
     for repo in repos:

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -3,13 +3,20 @@ from pathlib import Path
 import subprocess
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
-from axel.repo_manager import add_repo, load_repos  # noqa: E402
+from axel.repo_manager import add_repo, load_repos, remove_repo  # noqa: E402
 
 
 def test_add_and_load(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)
     assert load_repos(path=file) == ["https://example.com/repo"]
+
+
+def test_remove_repo(tmp_path: Path):
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    remove_repo("https://example.com/repo", path=file)
+    assert load_repos(path=file) == []
 
 
 def test_cli_list_with_path(tmp_path: Path):
@@ -23,3 +30,23 @@ def test_cli_list_with_path(tmp_path: Path):
         env={"PYTHONPATH": str(Path(__file__).resolve().parents[1])},
     )
     assert "https://example.com/repo" in result.stdout
+
+
+def test_cli_remove(tmp_path: Path):
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "axel.repo_manager",
+            "--path",
+            str(file),
+            "remove",
+            "https://example.com/repo",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env={"PYTHONPATH": str(Path(__file__).resolve().parents[1])},
+        check=True,
+    )
+    assert load_repos(path=file) == []


### PR DESCRIPTION
## Summary
- add `remove_repo` function and CLI command
- document new command in `README` with roadmap updates
- mention token.place integration goal
- enhance AGENTS.md with removal command and token.place note
- test repo removal via API and CLI

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_68547ba498dc832f98abc42d59fe77eb