### PR TITLE
Improve docs for private repo lists and issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .coverage
 htmlcov/
 pytest_cache/
+local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,7 @@ across projects. Repos are stored in `repos.txt` and managed via
   quests that connect multiple repositories.
 - Look for opportunities to integrate or document `token.place` clients across
   the repositories listed in `repos.txt`.
+- Keep markdown issues in the `issues/` folder up to date.
+- Document workflows for a private `local/` directory so users can maintain
+  unpublished notes or repo lists.
 - Refer to `CONTRIBUTORS.md` for more detailed contribution instructions.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ axel helps organize short, medium and long term goals using chat, reasoning and 
 - [ ] fetch repos from the GitHub API
 - [ ] integrate LLM assistants to suggest quests across repos
 - [ ] integrate `token.place` clients across all repos
+- [ ] represent personal flywheel of projects and highlight cross-pollination
+- [ ] document workflow for a private `local/` directory
+- [ ] track tasks with markdown files in the `issues/` folder
 
 ## usage
 
@@ -20,6 +23,20 @@ axel helps organize short, medium and long term goals using chat, reasoning and 
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Run `flake8 axel tests` and `pytest --cov=axel --cov=tests` before committing.
 5. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
+
+## local setup
+
+To keep personal notes and repo lists private, create a `local/` directory and
+add it to `.gitignore`. Set `AXEL_REPO_FILE=local/repos.txt` to use a private
+repo list without committing it to source control.
+
+Example:
+
+```bash
+mkdir -p local
+echo "https://github.com/your/private-repo" > local/repos.txt
+export AXEL_REPO_FILE=local/repos.txt
+```
 
 See `examples/` for a sample repo list.
 

--- a/issues/0001-private-local-dirs.md
+++ b/issues/0001-private-local-dirs.md
@@ -1,0 +1,7 @@
+# Issue 0001: Support Private Local Directories
+
+Users should be able to keep local notes and repos without publishing them. Document a workflow for creating a `local/` directory that is ignored by git and setting `AXEL_REPO_FILE=local/repos.txt`.
+
+- [ ] add instructions in README
+- [ ] provide example of `local/repos.txt`
+- [ ] ensure repo manager works with `AXEL_REPO_FILE`


### PR DESCRIPTION
## Summary
- document support for a private `local/` directory and issue tracker
- add roadmap items about personal flywheel and local workflow
- track Issue 0001 for local directories
- ignore `local/` in git
- update AGENTS guidelines

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_68548043e0e4832f8517299ab2b60a66