### PR TITLE
Add flywheel repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ across projects. Repos are stored in `repos.txt` and managed via
 - Look for opportunities to integrate or document `token.place` clients across
   the repositories listed in `repos.txt`.
 - Highlight synergies with [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel), an open-source OSINT agent that acts as a security layer across projects.
+- Use [`futuroptimist/flywheel`](https://github.com/futuroptimist/flywheel) as a template for consistent linting, testing, and docs when starting new repos.
 - Keep markdown issues in the `issues/` folder up to date.
 - Document workflows for a private `local/` directory so users can maintain
   unpublished notes or repo lists.

--- a/README.md
+++ b/README.md
@@ -58,5 +58,8 @@ The repos in `repos.txt` come from various projects like
 cross‑pollinate ideas between them by suggesting quests that touch multiple
 codebases.
 New additions such as [`gabriel`](https://github.com/futuroptimist/gabriel) help expand this flywheel by providing an open-source OSINT agent focused on personal safety.
+The [`flywheel`](https://github.com/futuroptimist/flywheel) template bundles
+linting, testing, and documentation checks so new repositories can start with
+healthy continuous integration from the beginning.
 
 See [CONTRIBUTORS.md](CONTRIBUTORS.md) for guidelines on sending pull requests.

--- a/examples/default/repos_example.txt
+++ b/examples/default/repos_example.txt
@@ -4,3 +4,5 @@ https://github.com/futuroptimist/futuroptimist
 https://github.com/futuroptimist/f2clipboard
 
 https://github.com/futuroptimist/gabriel
+
+https://github.com/futuroptimist/flywheel

--- a/issues/0004-flywheel-template.md
+++ b/issues/0004-flywheel-template.md
@@ -1,0 +1,7 @@
+# Issue 0004: Adopt Flywheel Template
+
+[`flywheel`](https://github.com/futuroptimist/flywheel) provides a GitHub template with preconfigured linting, testing and docs checks. Integrate it into new projects listed in `repos.txt` so they start with consistent CI pipelines.
+
+- [ ] mention flywheel in README and AGENTS guidelines
+- [ ] ensure repos.txt includes the flywheel repo
+- [ ] evaluate existing repos for alignment with flywheel's lint and test setup

--- a/repos.txt
+++ b/repos.txt
@@ -4,3 +4,5 @@ https://github.com/futuroptimist/futuroptimist
 https://github.com/futuroptimist/f2clipboard
 
 https://github.com/futuroptimist/gabriel
+
+https://github.com/futuroptimist/flywheel


### PR DESCRIPTION
## Summary
- include futuropimist/flywheel in repo lists
- mention flywheel in README guidance
- note flywheel template in AGENTS instructions
- add issue about adopting the flywheel template

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_6861cccf2dd0832f814ad04cffa485f5