### PR TITLE
Add packaging and flywheel tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install black isort
+      - name: Lint
+        run: |
+          flake8 axel tests
+          black --check axel tests
       - name: Run tests
         run: pytest --cov=axel --cov=tests
       - name: Upload coverage reports to Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: run tests
+        entry: pytest --cov=axel --cov=tests
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Thank you for helping improve **axel**!
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+pip install pre-commit
+pre-commit install
+```
+
+Run all checks before committing:
+
+```bash
+pre-commit run --all-files
+```
+
+## Pull Requests
+
+- Add tests for new functionality.
+- Keep the [roadmap](README.md#roadmap) updated when you close an item.
+- By submitting a PR you agree to license your work under the MIT license.
+
+For additional tips see [CONTRIBUTORS.md](CONTRIBUTORS.md).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 axel helps organize short, medium and long term goals using chat, reasoning and agentic LLMs. The project begins by keeping track of the GitHub repositories you contribute to. Over time it will fetch this list automatically and provide tools to analyze those repos and generate actionable quests.
 
 [![CI](https://github.com/futuroptimist/axel/actions/workflows/ci.yml/badge.svg)](https://github.com/futuroptimist/axel/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/futuroptimist/axel/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/axel)
 
 ## roadmap
 - [x] maintain a list of repos in `repos.txt`
@@ -17,12 +18,18 @@ axel helps organize short, medium and long term goals using chat, reasoning and 
 - [ ] document workflow for a private `local/` directory
 - [x] track tasks with markdown files in the `issues/` folder
 
+## installation
+
+```bash
+pip install -e .
+```
+
 ## usage
 
 1. Add a repo with `python -m axel.repo_manager add <url>` or edit `repos.txt`.
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
-4. Run `flake8 axel tests` and `pytest --cov=axel --cov=tests` before committing.
+4. Run `pre-commit run --all-files` before committing to check formatting and tests.
 5. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
 
 ## local setup
@@ -40,6 +47,15 @@ export AXEL_REPO_FILE=local/repos.txt
 ```
 
 See `examples/` for a sample repo list.
+
+## API
+
+```python
+from axel import add_repo, list_repos
+
+add_repo("https://github.com/example/repo")
+print(list_repos())
+```
 
 ## publishing
 
@@ -62,4 +78,5 @@ The [`flywheel`](https://github.com/futuroptimist/flywheel) template bundles
 linting, testing, and documentation checks so new repositories can start with
 healthy continuous integration from the beginning.
 
-See [CONTRIBUTORS.md](CONTRIBUTORS.md) for guidelines on sending pull requests.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on sending pull requests.
+For LLM-specific tips see [AGENTS.md](AGENTS.md).

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -1,0 +1,10 @@
+"""axel package."""
+
+from .repo_manager import add_repo, list_repos, load_repos, remove_repo
+
+__all__ = [
+    "add_repo",
+    "list_repos",
+    "load_repos",
+    "remove_repo",
+]

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -1,8 +1,7 @@
-from pathlib import Path
-from typing import List
-
 import argparse
 import os
+from pathlib import Path
+from typing import List
 
 DEFAULT_REPO_FILE = Path(
     os.getenv(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "axel"
+version = "0.1.0"
+description = "Personal repository tracker used by LLM assistants"
+readme = "README.md"
+authors = [{ name = "futuroptimist" }]
+license = { text = "MIT" }
+requires-python = ">=3.11"
+dependencies = ["requests"]
+packages = ["axel"]
+
+[project.urls]
+Homepage = "https://github.com/futuroptimist/axel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ flake8
 coverage
 pytest-cov
 requests
+black
+isort

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -1,9 +1,10 @@
+import importlib
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
-from axel.repo_manager import add_repo, load_repos, remove_repo  # noqa: E402
+from axel import add_repo, load_repos, remove_repo  # noqa: E402
 
 
 def test_add_and_load(tmp_path: Path):
@@ -50,3 +51,32 @@ def test_cli_remove(tmp_path: Path):
         check=True,
     )
     assert load_repos(path=file) == []
+
+
+def test_load_repos_missing_file(tmp_path: Path):
+    file = tmp_path / "missing.txt"
+    assert load_repos(path=file) == []
+
+
+def test_add_repo_no_duplicates(tmp_path: Path):
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    add_repo("https://example.com/repo", path=file)
+    assert load_repos(path=file) == ["https://example.com/repo"]
+
+
+def test_remove_repo_missing(tmp_path: Path):
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    remove_repo("https://example.com/other", path=file)
+    assert load_repos(path=file) == ["https://example.com/repo"]
+
+
+def test_env_default_var(monkeypatch, tmp_path: Path):
+    repo_file = tmp_path / "repos.txt"
+    monkeypatch.setenv("AXEL_REPO_FILE", str(repo_file))
+    import axel.repo_manager as rm
+
+    importlib.reload(rm)
+    rm.add_repo("https://example.com/repo")
+    assert repo_file.read_text().strip() == "https://example.com/repo"


### PR DESCRIPTION
## Summary
- expose repo manager functions in `__init__`
- add `pyproject.toml` for packaging
- expand tests for edge cases
- add pre-commit and Dependabot configs
- update CI to run lint and format checks
- document installation, API usage and contribution steps

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_686245ec6d60832f87035ee8dac77aef