### PR TITLE
Increase repo_manager coverage

### DIFF
--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -80,3 +80,47 @@ def test_env_default_var(monkeypatch, tmp_path: Path):
     importlib.reload(rm)
     rm.add_repo("https://example.com/repo")
     assert repo_file.read_text().strip() == "https://example.com/repo"
+
+
+def test_remove_repo_leaves_newline(tmp_path: Path) -> None:
+    """Line 38 in remove_repo appends a trailing newline when repos remain."""
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo1", path=file)
+    add_repo("https://example.com/repo2", path=file)
+    remove_repo("https://example.com/repo1", path=file)
+    assert file.read_text() == "https://example.com/repo2\n"
+
+
+def test_cli_add_and_list_direct(tmp_path: Path, capsys) -> None:
+    """Call ``main`` directly to include CLI logic in coverage metrics."""
+    from axel import repo_manager as rm
+
+    file = tmp_path / "repos.txt"
+    rm.main(["--path", str(file), "add", "https://example.com/repo"])  # add
+    output = capsys.readouterr().out.strip()
+    assert output == "https://example.com/repo"
+
+    rm.main(["--path", str(file), "list"])  # list
+    output = capsys.readouterr().out.strip()
+    assert output == "https://example.com/repo"
+
+
+def test_cli_default_lists(tmp_path: Path, capsys) -> None:
+    """When no subcommand is provided the repo list is printed."""
+    from axel import repo_manager as rm
+
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    rm.main(["--path", str(file)])
+    assert capsys.readouterr().out.strip() == "https://example.com/repo"
+
+
+def test_cli_remove_direct(tmp_path: Path, capsys) -> None:
+    """Direct call of ``main`` covers the ``remove`` branch."""
+    from axel import repo_manager as rm
+
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    rm.main(["--path", str(file), "remove", "https://example.com/repo"])  # remove
+    assert capsys.readouterr().out.strip() == ""
+    assert not file.read_text()


### PR DESCRIPTION
## Summary
- add direct CLI tests for repo_manager
- test newline handling when a repo remains

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_6868c85beff4832fb802ddb223767939