### PR TITLE
Improve repo file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ axel helps organize short, medium and long term goals using chat, reasoning and 
 - [ ] integrate `token.place` clients across all repos
 - [ ] integrate [`gabriel`](https://github.com/futuroptimist/gabriel) as a security layer across repos
 - [ ] represent personal flywheel of projects and highlight cross-pollination
-- [ ] document workflow for a private `local/` directory
+- [x] document workflow for a private `local/` directory
 - [x] track tasks with markdown files in the `issues/` folder
 
 ## installation

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -1,9 +1,16 @@
 """axel package."""
 
-from .repo_manager import add_repo, list_repos, load_repos, remove_repo
+from .repo_manager import (
+    add_repo,
+    get_repo_file,
+    list_repos,
+    load_repos,
+    remove_repo,
+)
 
 __all__ = [
     "add_repo",
+    "get_repo_file",
     "list_repos",
     "load_repos",
     "remove_repo",

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -3,24 +3,28 @@ import os
 from pathlib import Path
 from typing import List
 
-DEFAULT_REPO_FILE = Path(
-    os.getenv(
-        "AXEL_REPO_FILE",
-        Path(__file__).resolve().parent.parent / "repos.txt",
-    )
-)
+DEFAULT_REPO_FILE = Path(__file__).resolve().parent.parent / "repos.txt"
 
 
-def load_repos(path: Path = DEFAULT_REPO_FILE) -> List[str]:
+def get_repo_file() -> Path:
+    """Return the repository list path, honoring ``AXEL_REPO_FILE`` if set."""
+    return Path(os.getenv("AXEL_REPO_FILE", DEFAULT_REPO_FILE))
+
+
+def load_repos(path: Path | None = None) -> List[str]:
     """Load repository URLs from a text file."""
+    if path is None:
+        path = get_repo_file()
     if not path.exists():
         return []
     with path.open() as f:
         return [line.strip() for line in f if line.strip()]
 
 
-def add_repo(url: str, path: Path = DEFAULT_REPO_FILE) -> List[str]:
+def add_repo(url: str, path: Path | None = None) -> List[str]:
     """Add a repository URL to the list if not already present."""
+    if path is None:
+        path = get_repo_file()
     repos = load_repos(path)
     if url not in repos:
         repos.append(url)
@@ -28,8 +32,10 @@ def add_repo(url: str, path: Path = DEFAULT_REPO_FILE) -> List[str]:
     return repos
 
 
-def remove_repo(url: str, path: Path = DEFAULT_REPO_FILE) -> List[str]:
+def remove_repo(url: str, path: Path | None = None) -> List[str]:
     """Remove a repository URL from the list if present."""
+    if path is None:
+        path = get_repo_file()
     repos = load_repos(path)
     if url in repos:
         repos.remove(url)
@@ -40,7 +46,7 @@ def remove_repo(url: str, path: Path = DEFAULT_REPO_FILE) -> List[str]:
     return repos
 
 
-def list_repos(path: Path = DEFAULT_REPO_FILE) -> List[str]:
+def list_repos(path: Path | None = None) -> List[str]:
     """Return the list of repository URLs."""
     return load_repos(path)
 
@@ -51,7 +57,7 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument(
         "--path",
         type=Path,
-        default=DEFAULT_REPO_FILE,
+        default=get_repo_file(),
         help="Path to repo list",
     )
     sub = parser.add_subparsers(dest="cmd")

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -82,6 +82,16 @@ def test_env_default_var(monkeypatch, tmp_path: Path):
     assert repo_file.read_text().strip() == "https://example.com/repo"
 
 
+def test_env_dynamic_at_runtime(monkeypatch, tmp_path: Path) -> None:
+    """``AXEL_REPO_FILE`` is honored without reloading the module."""
+    repo_file = tmp_path / "repos_runtime.txt"
+    monkeypatch.setenv("AXEL_REPO_FILE", str(repo_file))
+    import axel.repo_manager as rm
+
+    rm.add_repo("https://example.com/runtime")
+    assert repo_file.read_text().strip() == "https://example.com/runtime"
+
+
 def test_remove_repo_leaves_newline(tmp_path: Path) -> None:
     """Line 38 in remove_repo appends a trailing newline when repos remain."""
     file = tmp_path / "repos.txt"


### PR DESCRIPTION
## Summary
- access `AXEL_REPO_FILE` at runtime via `get_repo_file`
- export `get_repo_file`
- mark `local/` workflow as finished in the roadmap
- test that changing `AXEL_REPO_FILE` after import works

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_6869b0cca09c832fbc8f3de7e57ad3c7