### PR TITLE
Increase coverage to 100%

### DIFF
--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -134,3 +134,25 @@ def test_cli_remove_direct(tmp_path: Path, capsys) -> None:
     rm.main(["--path", str(file), "remove", "https://example.com/repo"])  # remove
     assert capsys.readouterr().out.strip() == ""
     assert not file.read_text()
+
+
+def test_load_repos_defaults(monkeypatch, tmp_path: Path) -> None:
+    """When no path is provided ``AXEL_REPO_FILE`` is used."""
+    repo_file = tmp_path / "repos.txt"
+    monkeypatch.setenv("AXEL_REPO_FILE", str(repo_file))
+    import axel.repo_manager as rm
+
+    assert rm.load_repos() == []  # file doesn't exist yet
+    rm.add_repo("https://example.com/repo")  # default path
+    assert rm.load_repos() == ["https://example.com/repo"]
+
+
+def test_remove_repo_defaults(monkeypatch, tmp_path: Path) -> None:
+    """``remove_repo`` should also honor ``AXEL_REPO_FILE``."""
+    repo_file = tmp_path / "repos.txt"
+    monkeypatch.setenv("AXEL_REPO_FILE", str(repo_file))
+    import axel.repo_manager as rm
+
+    rm.add_repo("https://example.com/repo")
+    rm.remove_repo("https://example.com/repo")
+    assert rm.load_repos() == []


### PR DESCRIPTION
## Summary
- cover the default path logic in `load_repos` and `remove_repo`

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`


------
https://chatgpt.com/codex/tasks/task_e_6869b22d5330832f809cc739e54f8a45