### PR TITLE
Add Discord bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ axel helps organize short, medium and long term goals using chat, reasoning and 
 - [ ] integrate LLM assistants to suggest quests across repos
 - [ ] integrate `token.place` clients across all repos
 - [ ] integrate [`gabriel`](https://github.com/futuroptimist/gabriel) as a security layer across repos
+- [ ] self-hosted Discord bot for ingesting messages when mentioned
 - [ ] represent personal flywheel of projects and highlight cross-pollination
 - [x] document workflow for a private `local/` directory
 - [x] track tasks with markdown files in the `issues/` folder
@@ -56,6 +57,11 @@ from axel import add_repo, list_repos
 add_repo("https://github.com/example/repo")
 print(list_repos())
 ```
+
+## discord bot
+
+See [docs/discord-bot.md](docs/discord-bot.md) for running a local Discord bot
+that saves mentioned messages to `local/discord/`.
 
 ## publishing
 

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -7,6 +7,7 @@ from .repo_manager import (
     load_repos,
     remove_repo,
 )
+from .discord_bot import run as run_discord_bot
 
 __all__ = [
     "add_repo",
@@ -14,4 +15,5 @@ __all__ = [
     "list_repos",
     "load_repos",
     "remove_repo",
+    "run_discord_bot",
 ]

--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -1,0 +1,46 @@
+"""Minimal Discord bot for ingesting messages mentioned by users."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import discord
+
+SAVE_DIR = Path("local/discord")
+SAVE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def save_message(message: discord.Message) -> Path:
+    """Persist the provided message as markdown."""
+    path = SAVE_DIR / f"{message.id}.md"
+    content = f"# {message.author.display_name}\n\n{message.content}\n"
+    path.write_text(content)
+    return path
+
+
+class AxelClient(discord.Client):
+    async def on_ready(self) -> None:  # pragma: no cover - network call
+        print(f"Logged in as {self.user}")
+
+    async def on_message(self, message: discord.Message) -> None:  # pragma: no cover
+        if self.user is None or message.author == self.user:
+            return
+        if self.user.mentioned_in(message) and message.reference:
+            original = await message.channel.fetch_message(
+                message.reference.message_id
+            )
+            path = save_message(original)
+            await message.channel.send(f"Saved to {path}")
+
+
+def run() -> None:
+    token = os.environ.get("DISCORD_BOT_TOKEN")
+    if not token:
+        raise SystemExit("DISCORD_BOT_TOKEN not set")
+    client = AxelClient(intents=discord.Intents.default())
+    client.run(token)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    run()

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -1,0 +1,33 @@
+# Self-Hosted Discord Bot
+
+This document outlines a proposed architecture for running a local Discord bot
+that ingests messages from your server.
+
+## Goals
+
+- Allow a user to invite a bot to their personal server using the standard
+  Discord bot OAuth flow.
+- Keep all bot logic and data on the user's machine to avoid leaking private
+  information.
+- When the bot is mentioned in a reply, download the parent message and store a
+  local copy for future reference.
+- Persist messages under `local/discord/` which is gitignored by default.
+
+## Launching the Bot
+
+```bash
+python -m axel.discord_bot
+```
+
+This will start the bot using the token set in the `DISCORD_BOT_TOKEN`
+environment variable. Once running, it appears online in the server.
+
+## Usage
+
+Mention the bot in reply to any message you want to save. The bot fetches the
+original message, asks for clarification if needed, then writes a markdown file
+under `local/discord/<message_id>.md`.
+
+Future iterations can analyze these notes alongside `token.place` and
+[`gabriel`](https://github.com/futuroptimist/gabriel) to suggest quests across
+repositories.

--- a/issues/0005-discord-bot-ingest.md
+++ b/issues/0005-discord-bot-ingest.md
@@ -1,0 +1,11 @@
+# Issue 0005: Self-Hosted Discord Bot Ingestion
+
+Add a simple Discord bot that users can run locally. When mentioned in a reply,
+the bot downloads the parent message and stores it under `local/discord/`.
+This keeps any notes private while making them accessible to axel for
+future LLM-powered quests.
+
+- [ ] create `axel.discord_bot` module
+- [ ] document workflow in `docs/discord-bot.md`
+- [ ] update roadmap with this feature
+- [ ] explore integrations with `token.place` and `gabriel`

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 requests
 black
 isort
+discord.py

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+import axel.discord_bot as db  # noqa: E402
+
+
+class DummyAuthor:
+    display_name = "user"
+
+
+class DummyMessage:
+    def __init__(self, content: str, mid: int = 1) -> None:
+        self.content = content
+        self.id = mid
+        self.author = DummyAuthor()
+
+
+def test_save_message(tmp_path: Path) -> None:
+    db.SAVE_DIR = tmp_path
+    msg = DummyMessage("hello")
+    path = db.save_message(msg)
+    assert path.read_text() == "# user\n\nhello\n"


### PR DESCRIPTION
## Summary
- add roadmap entry and docs for running a local Discord bot
- include a skeleton `axel.discord_bot` module
- export `run_discord_bot` from package
- track the feature in issues
- test `save_message`
- require `discord.py`

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_6869bd63b568832f921ce128ae94b189