### PR TITLE
Improve tests to reach 100% coverage

### DIFF
--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,6 +1,9 @@
 import sys
 from pathlib import Path
 
+import discord
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
 
 import axel.discord_bot as db  # noqa: E402
@@ -22,3 +25,31 @@ def test_save_message(tmp_path: Path) -> None:
     msg = DummyMessage("hello")
     path = db.save_message(msg)
     assert path.read_text() == "# user\n\nhello\n"
+
+
+def test_run_missing_token(monkeypatch) -> None:
+    """``run`` exits if ``DISCORD_BOT_TOKEN`` is not set."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    with pytest.raises(SystemExit):
+        db.run()
+
+
+def test_run_invokes_client(monkeypatch) -> None:
+    """``run`` initializes and runs ``AxelClient`` with the token."""
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self, *, intents: object) -> None:
+            captured["intents"] = intents
+
+        def run(self, token: str) -> None:
+            captured["token"] = token
+
+    monkeypatch.setattr(db, "AxelClient", DummyClient)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "123")
+
+    db.run()
+
+    assert captured["token"] == "123"
+    assert captured["intents"] == discord.Intents.default()


### PR DESCRIPTION
## Summary
- cover the Discord bot CLI helpers

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_6869c1e2ab74832fba9ecaed3f01a43f