### PR TITLE
Add Codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: yes
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0
+    patch:
+      default:
+        target: 90
+comment:
+  layout: "header, diff"

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest --cov=axel --cov=tests
+          pytest --cov=axel --cov=tests --cov-report=xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,6 @@ repos:
     hooks:
       - id: pytest
         name: run tests
-        entry: pytest --cov=axel --cov=tests
+        entry: pytest --cov=axel --cov=tests --cov-report=xml
         language: system
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ pre-commit install
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Run `pre-commit run --all-files` before committing to check formatting and tests.
 5. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
+6. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
 
 ## local setup
 

--- a/issues/0003-gabriel-security-layer.md
+++ b/issues/0003-gabriel-security-layer.md
@@ -5,4 +5,3 @@
 - [ ] add examples of using gabriel alongside `token.place` and `dspace`
 - [ ] mention gabriel in future quests that involve sensitive data
 - [ ] keep README entries updated as integration progresses
-


### PR DESCRIPTION
## Summary
- generate `coverage.xml` in pre-commit and CI
- upload coverage reports to Codecov with error handling
- configure coverage thresholds via `.codecov.yml`
- mention Codecov in README
- fix EOF newline in issue file

## Testing
- `pre-commit run --all-files`
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

------
https://chatgpt.com/codex/tasks/task_e_68882b266f6c832f9825e1a6b26aaa30