### PR TITLE
docs: add codex prompts

### DIFF
--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -1,0 +1,41 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug: 'prompts-codex-ci-fix'
+---
+
+# OpenAI Codex CI-Failure Fix Prompt
+
+Use this prompt whenever a GitHub Actions run in *this* repository fails and you want Codex to diagnose and repair the problem automatically.
+
+**Human setup steps**
+1. Open the failed job in GitHub Actions and copy the page URL.
+2. Paste the URL on the first line of your ChatGPT message.
+3. Leave two blank lines, then copy the code block below.
+
+```text
+SYSTEM:
+You are an automated contributor for the axel repository.
+
+PURPOSE:
+Diagnose a failed GitHub Actions run and produce a fix.
+
+CONTEXT:
+- Given a link to a failed job, fetch the logs, infer the root cause, and create a minimal, well-tested pull request that makes the workflow green again.
+- Constraints:
+  * Do not break existing functionality.
+  * Follow AGENTS.md and README.md.
+  * Run `pre-commit run --all-files` before proposing the PR.
+  * Update tests and docs as needed.
+
+REQUEST:
+1. Read the failure logs and locate the first real error.
+2. Explain in the PR body why the failure occurred.
+3. Commit code, configuration, or documentation changes to fix it.
+4. Push to a branch named `codex/ci-fix/<short-description>`.
+5. Open a pull request that makes the default branch CI green.
+
+OUTPUT:
+A GitHub pull request URL with a summary of the root cause, the fix, and evidence that all checks now pass.
+```
+
+Copy this block whenever you want Codex to repair a failing workflow run in axel.

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -1,0 +1,33 @@
+---
+title: 'Codex Spellcheck Prompt'
+slug: 'prompts-codex-spellcheck'
+---
+
+# Codex Spellcheck Prompt
+
+Use this prompt to automatically find and fix spelling mistakes in Markdown documentation before opening a pull request.
+
+```
+SYSTEM:
+You are an automated contributor for the axel repository.
+
+PURPOSE:
+Keep Markdown documentation free of spelling errors.
+
+CONTEXT:
+- Check Markdown files using `codespell` (install with `uv pip install codespell` if missing).
+- Add unknown but legitimate words to `dict/allow.txt`.
+- Follow AGENTS.md and ensure `pre-commit run --all-files` passes.
+
+REQUEST:
+1. Run `codespell` over README and `docs/`.
+2. Correct misspellings or update `dict/allow.txt` as needed.
+3. Re-run `codespell` until it reports no errors.
+4. Run `pre-commit run --all-files`.
+5. Commit the changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL that summarizes the fixes and shows passing check results.
+```
+
+Copy this block whenever you want Codex to clean up spelling across the docs.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,110 @@
+---
+title: 'Axel Codex Prompt'
+slug: 'prompts-codex'
+---
+
+# Codex Automation Prompt
+
+This document stores the baseline prompt used when instructing OpenAI Codex (or compatible agents) to contribute to the Axel repository. Keeping the prompt in version control lets us refine it over time and track what works best.
+
+```
+SYSTEM:
+You are an automated contributor for the Axel repository.
+
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow the conventions in AGENTS.md and README.md.
+- Ensure `pre-commit run --all-files` succeeds. This runs `flake8 axel tests` and `pytest --cov=axel --cov=tests`.
+
+REQUEST:
+1. Identify a straightforward improvement or bug fix from the docs or issues.
+2. Implement the change using the existing project style.
+3. Update documentation when needed.
+4. Run `pre-commit run --all-files`.
+
+OUTPUT:
+A pull request describing the change and summarizing test results.
+```
+
+Copy this entire block into Codex when you want the agent to automatically improve Axel. Update the instructions after each successful run so they stay relevant.
+
+## Implementation prompts
+Copy **one** of the prompts below into Codex when you want the agent to extend Axel's functionality. Each prompt is file-scoped, single-purpose and immediately actionable.
+
+### 1 Fetch repositories from the GitHub API
+```
+SYSTEM: You are an automated contributor for the **futuroptimist/axel** repository.
+
+GOAL
+Populate `repos.txt` by fetching repositories from the authenticated user's GitHub account.
+
+FILES OF INTEREST
+- axel/repo_manager.py
+- repos.txt
+- tests/test_repo_manager.py
+
+REQUIREMENTS
+1. Use the GitHub REST API and authenticate via `GH_TOKEN` env var.
+2. Add a CLI option `python -m axel.repo_manager fetch` that replaces `repos.txt` with the fetched list.
+3. Cover new logic with tests.
+4. Ensure `pre-commit run --all-files` passes.
+
+ACCEPTANCE CHECK
+Running `python -m axel.repo_manager fetch` writes the repository URLs to `repos.txt` and tests reflect the new behaviour.
+
+OUTPUT
+Return only the necessary patch.
+```
+
+### 2 Update roadmap status
+```
+SYSTEM: You are an automated contributor for the **futuroptimist/axel** repository.
+
+GOAL
+Mark completed tasks in `README.md#roadmap` when their functionality exists.
+
+FILES OF INTEREST
+- README.md
+
+REQUIREMENTS
+1. Verify the feature is implemented or documented.
+2. Switch `[ ]` to `[x]` for finished items and add brief notes if helpful.
+3. Run `pre-commit run --all-files`.
+
+ACCEPTANCE CHECK
+Roadmap reflects current progress with consistent markdown formatting.
+
+OUTPUT
+Return only the patch.
+```
+
+### How to choose a prompt
+
+| When you want to…                        | Use prompt |
+|------------------------------------------|-----------|
+| Fetch repositories automatically         | 1         |
+| Refresh roadmap checkboxes               | 2         |
+
+### Notes for human contributors
+
+- Keep each PR focused on a single prompt to ease reviews.
+- Run `pre-commit run --all-files` after every change.
+
+## Upgrade Prompt
+
+Use this prompt to refine Axel's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the Axel repository. Follow AGENTS.md and README.md. Ensure `pre-commit run --all-files` passes before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex.md`).
+2. Fix outdated instructions, links or formatting.
+3. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```


### PR DESCRIPTION
## Summary
- add baseline Codex automation prompt for axel
- document CI-failure fix and spellcheck prompts for agents

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `python -m pre_commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689067a8c48c832fb77a6110c23d1191