### PR TITLE
🐛: trim whitespace around repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pre-commit install
 ## usage
 
 1. Add a repo with `python -m axel.repo_manager add <url>` or edit `repos.txt`.
+   Whitespace around the URL is stripped automatically.
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Run `pre-commit run --all-files` before committing to check formatting and tests.

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -25,8 +25,9 @@ def add_repo(url: str, path: Path | None = None) -> List[str]:
     """Add a repository URL to the list if not already present."""
     if path is None:
         path = get_repo_file()
+    url = url.strip()
     repos = load_repos(path)
-    if url not in repos:
+    if url and url not in repos:
         repos.append(url)
         path.write_text("\n".join(repos) + "\n")
     return repos
@@ -36,6 +37,7 @@ def remove_repo(url: str, path: Path | None = None) -> List[str]:
     """Remove a repository URL from the list if present."""
     if path is None:
         path = get_repo_file()
+    url = url.strip()
     repos = load_repos(path)
     if url in repos:
         repos.remove(url)

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -65,11 +65,24 @@ def test_add_repo_no_duplicates(tmp_path: Path):
     assert load_repos(path=file) == ["https://example.com/repo"]
 
 
+def test_add_repo_strips_whitespace(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo\n", path=file)
+    assert load_repos(path=file) == ["https://example.com/repo"]
+
+
 def test_remove_repo_missing(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)
     remove_repo("https://example.com/other", path=file)
     assert load_repos(path=file) == ["https://example.com/repo"]
+
+
+def test_remove_repo_strips_whitespace(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    remove_repo("https://example.com/repo \n", path=file)
+    assert load_repos(path=file) == []
 
 
 def test_env_default_var(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- strip whitespace in `add_repo` and `remove_repo`
- test and document trimming behavior

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6892de03b3e4832f947019a8920d59d8