### PR TITLE
📝 : document secret scan in codex prompt

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -19,6 +19,8 @@ Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Follow the conventions in AGENTS.md and README.md.
+- Search for secrets with
+  `git ls-files -z | xargs -0 grep -i --line-number --context=1 -e token -e secret -e password`.
 - Ensure `pre-commit run --all-files` succeeds. This runs formatting checks,
   `flake8`, and `pytest --cov=axel --cov=tests`.
 
@@ -36,12 +38,12 @@ Copy this entire block into your LLM chat when you want the agent to
 automatically improve Axel. Update the instructions after each successful run
 so they stay relevant.
 
-## Implementation prompts
+## Implementation Prompts
 Copy **one** of the prompts below into the LLM when you want the agent to extend
 Axel's functionality. Each prompt is file-scoped, single-purpose and immediately
 actionable.
 
-### 1 Fetch repositories from the GitHub API
+### 1. Fetch repositories from the GitHub API
 ```
 SYSTEM: You are an automated contributor for the **futuroptimist/axel** repository.
 
@@ -68,7 +70,7 @@ OUTPUT
 Return only the necessary patch.
 ```
 
-### 2 Update roadmap status
+### 2. Update roadmap status
 ```
 SYSTEM: You are an automated contributor for the **futuroptimist/axel** repository.
 
@@ -90,14 +92,14 @@ OUTPUT
 Return only the patch.
 ```
 
-### How to choose a prompt
+### How to Choose a Prompt
 
 | When you want to…                        | Use prompt |
 |------------------------------------------|-----------|
 | Fetch repositories automatically         | 1         |
 | Refresh roadmap checkboxes               | 2         |
 
-### Notes for human contributors
+### Notes for Human Contributors
 
 - Keep each PR focused on a single prompt to ease reviews.
 - Run `pre-commit run --all-files` after every change.


### PR DESCRIPTION
what: document secret scanning and tidy prompt headings.
why: keep instructions current with repo security conventions.
how to test:
- flake8 axel tests
- pytest --cov=axel --cov=tests
- linkchecker README.md docs/
- pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_e_6893e1cb23d0832f9eec4a7236d6098d