### PR TITLE
🛠️: ensure discord save dir exists

### DIFF
--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -8,11 +8,14 @@ from pathlib import Path
 import discord
 
 SAVE_DIR = Path("local/discord")
-SAVE_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def save_message(message: discord.Message) -> Path:
-    """Persist the provided message as markdown."""
+    """Persist the provided message as markdown.
+
+    Ensures the save directory exists before writing.
+    """
+    SAVE_DIR.mkdir(parents=True, exist_ok=True)
     path = SAVE_DIR / f"{message.id}.md"
     content = f"# {message.author.display_name}\n\n{message.content}\n"
     path.write_text(content)

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -25,8 +25,9 @@ environment variable. Once running, it appears online in the server.
 ## Usage
 
 Mention the bot in reply to any message you want to save. The bot fetches the
-original message, asks for clarification if needed, then writes a markdown file
-under `local/discord/<message_id>.md`.
+original message and writes a markdown file under
+`local/discord/<message_id>.md`. The directory is created automatically if it
+doesn't exist.
 
 Future iterations can analyze these notes alongside `token.place` and
 [`gabriel`](https://github.com/futuroptimist/gabriel) to suggest quests across

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -27,6 +27,15 @@ def test_save_message(tmp_path: Path) -> None:
     assert path.read_text() == "# user\n\nhello\n"
 
 
+def test_save_message_creates_dir(tmp_path: Path) -> None:
+    missing = tmp_path / "discord"
+    db.SAVE_DIR = missing
+    msg = DummyMessage("hi", mid=2)
+    path = db.save_message(msg)
+    assert path.read_text() == "# user\n\nhi\n"
+    assert missing.exists()
+
+
 def test_run_missing_token(monkeypatch) -> None:
     """``run`` exits if ``DISCORD_BOT_TOKEN`` is not set."""
     monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)


### PR DESCRIPTION
what: create SAVE_DIR before writing discord messages
why: avoid crashes when save path is missing
how to test: pre-commit run --all-files
Refs: #0005

------
https://chatgpt.com/codex/tasks/task_e_6893e1b8bc50832f82f5e7300b46f6eb