### PR TITLE
🐛: create parent dirs for repo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ pre-commit install
 
 ## local setup
 
-To keep personal notes and repo lists private, create a `local/` directory and
-add it to `.gitignore`. Set `AXEL_REPO_FILE=local/repos.txt` to use a private
-repo list without committing it to source control.
+To keep personal notes and repo lists private, set `AXEL_REPO_FILE` to a path
+under `local/`, which is gitignored. The repo manager creates the directory
+automatically if it doesn't already exist.
 
 Example:
 
 ```bash
-mkdir -p local
-echo "https://github.com/your/private-repo" > local/repos.txt
+python -m axel.repo_manager add https://github.com/your/private-repo --path local/repos.txt
 export AXEL_REPO_FILE=local/repos.txt
 git check-ignore -v local/
 ```
 
-The final command confirms that your `local/` directory is excluded from version control.
+The `git check-ignore` command confirms that `local/` is excluded from version
+control.
 
 See `examples/` for a sample repo list.
 

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -25,6 +25,7 @@ def add_repo(url: str, path: Path | None = None) -> List[str]:
     """Add a repository URL to the list if not already present."""
     if path is None:
         path = get_repo_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
     url = url.strip()
     repos = load_repos(path)
     if url and url not in repos:
@@ -37,6 +38,7 @@ def remove_repo(url: str, path: Path | None = None) -> List[str]:
     """Remove a repository URL from the list if present."""
     if path is None:
         path = get_repo_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
     url = url.strip()
     repos = load_repos(path)
     if url in repos:

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -71,6 +71,12 @@ def test_add_repo_strips_whitespace(tmp_path: Path) -> None:
     assert load_repos(path=file) == ["https://example.com/repo"]
 
 
+def test_add_repo_creates_parent_dir(tmp_path: Path) -> None:
+    file = tmp_path / "nested" / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    assert file.read_text() == "https://example.com/repo\n"
+
+
 def test_remove_repo_missing(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
## Summary
- ensure repo_manager creates parent directories for custom repo files
- document auto-directory creation in local setup instructions
- test add_repo works with non-existent parent directory

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file)*

------
https://chatgpt.com/codex/tasks/task_e_6893e1b8bc50832f82f5e7300b46f6eb