### PR TITLE
Expand AXEL_REPO_FILE path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ pre-commit install
 
 To keep personal notes and repo lists private, set `AXEL_REPO_FILE` to a path
 under `local/`, which is gitignored. The repo manager creates the directory
-automatically if it doesn't already exist.
+automatically if it doesn't already exist. Paths beginning with `~` expand to
+the user's home directory.
 
 Example:
 

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -7,8 +7,11 @@ DEFAULT_REPO_FILE = Path(__file__).resolve().parent.parent / "repos.txt"
 
 
 def get_repo_file() -> Path:
-    """Return the repository list path, honoring ``AXEL_REPO_FILE`` if set."""
-    return Path(os.getenv("AXEL_REPO_FILE", DEFAULT_REPO_FILE))
+    """Return the repository list path, honoring ``AXEL_REPO_FILE`` if set.
+
+    ``AXEL_REPO_FILE`` may include a ``~`` to reference the user's home directory.
+    """
+    return Path(os.getenv("AXEL_REPO_FILE", DEFAULT_REPO_FILE)).expanduser()
 
 
 def load_repos(path: Path | None = None) -> List[str]:

--- a/issues/0001-private-local-dirs.md
+++ b/issues/0001-private-local-dirs.md
@@ -4,4 +4,4 @@ Users should be able to keep local notes and repos without publishing them. Docu
 
 - [x] add instructions in README
 - [x] provide example of `local/repos.txt`
-- [ ] ensure repo manager works with `AXEL_REPO_FILE`
+ - [x] ensure repo manager works with `AXEL_REPO_FILE`

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -111,6 +111,19 @@ def test_env_dynamic_at_runtime(monkeypatch, tmp_path: Path) -> None:
     assert repo_file.read_text().strip() == "https://example.com/runtime"
 
 
+def test_env_var_expands_user(monkeypatch, tmp_path: Path) -> None:
+    """``AXEL_REPO_FILE`` supports ``~`` expansion."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("AXEL_REPO_FILE", "~/repos.txt")
+    import axel.repo_manager as rm
+
+    rm.add_repo("https://example.com/tilde")
+    assert rm.get_repo_file() == home / "repos.txt"
+    assert (home / "repos.txt").read_text().strip() == "https://example.com/tilde"
+
+
 def test_remove_repo_leaves_newline(tmp_path: Path) -> None:
     """Line 38 in remove_repo appends a trailing newline when repos remain."""
     file = tmp_path / "repos.txt"


### PR DESCRIPTION
## Summary
- expand `AXEL_REPO_FILE` to support `~` home directory expansion
- document custom repo path usage and mark issue 0001 complete

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689436750320832f9f3974e7eccb700e