### PR TITLE
📝 : update secret scan instructions in prompts codex

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -19,7 +19,12 @@ Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Follow the conventions in [AGENTS.md](../AGENTS.md) and [README.md](../README.md).
-- Scan for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan for secrets:
+
+  ```bash
+  git ls-files -z | xargs -0 grep -i --line-number --context=1 \
+    -e token -e secret -e password
+  ```
 - Ensure `pre-commit run --all-files` succeeds. This runs formatting checks, `flake8`,
   and `pytest --cov=axel --cov=tests`.
 


### PR DESCRIPTION
what: replace missing script reference in docs/prompts-codex.md.
why: align secret scanning guidance with README.
how to test: flake8 axel tests; pytest --cov=axel --cov=tests; pre-commit run --all-files.


------
https://chatgpt.com/codex/tasks/task_e_689462059ce0832f8a75321f57160454