### PR TITLE
✨ : ignore comments in repo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pre-commit install
 ## usage
 
 1. Add a repo with `python -m axel.repo_manager add <url>` or edit `repos.txt`.
+   Lines starting with `#` or with trailing `#` comments are ignored.
    Whitespace around the URL is stripped automatically.
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -22,8 +22,14 @@ def load_repos(path: Path | None = None) -> List[str]:
         path = get_repo_file()
     if not path.exists():
         return []
+    repos: List[str] = []
     with path.open() as f:
-        return [line.strip() for line in f if line.strip()]
+        for line in f:
+            # Allow comments using ``#`` and strip inline notes
+            line = line.split("#", 1)[0].strip()
+            if line:
+                repos.append(line)
+    return repos
 
 
 def add_repo(url: str, path: Path | None = None) -> List[str]:

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -61,6 +61,19 @@ def test_load_repos_missing_file(tmp_path: Path):
     assert load_repos(path=file) == []
 
 
+def test_load_repos_ignores_comments(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    file.write_text(
+        "https://example.com/a\n"
+        "# comment line\n"
+        "https://example.com/b # trailing comment\n"
+    )
+    assert load_repos(path=file) == [
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+
+
 def test_add_repo_no_duplicates(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
## Summary
- allow repos.txt to contain comment lines
- document comment support

## Testing
- `pre-commit run --all-files`
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`

Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_689461f522a8832f98c1c7707806eea2