### PR TITLE
fix: install test dependencies in CI

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -19,6 +19,7 @@ jobs:
           uv venv .venv
           source .venv/bin/activate
           uv pip install -r requirements.txt
+          uv pip install pytest pytest-cov discord.py
       - name: Run tests
         run: |
           source .venv/bin/activate


### PR DESCRIPTION
## What
- install pytest, pytest-cov, and discord.py in test workflow

## Why
- ensure CI runs pytest without missing modules

## How to Test
- `pre-commit run --all-files`

Refs: 


------
https://chatgpt.com/codex/tasks/task_e_6895924c3078832fb4f14cec7adeb5a6