### PR TITLE
✨ : add task manager CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ pre-commit install
 5. Run `pre-commit run --all-files` before committing to check formatting and tests.
 6. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
+8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
+   saved in `tasks.json` and listed with `python -m axel.task_manager list`.
 
 ## local setup
 

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -2,6 +2,7 @@
 
 from .discord_bot import run as run_discord_bot
 from .repo_manager import add_repo, get_repo_file, list_repos, load_repos, remove_repo
+from .task_manager import add_task, get_task_file, list_tasks, load_tasks
 
 __all__ = [
     "add_repo",
@@ -10,4 +11,8 @@ __all__ = [
     "load_repos",
     "remove_repo",
     "run_discord_bot",
+    "add_task",
+    "get_task_file",
+    "list_tasks",
+    "load_tasks",
 ]

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -1,0 +1,70 @@
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+DEFAULT_TASK_FILE = Path(__file__).resolve().parent.parent / "tasks.json"
+
+
+def get_task_file() -> Path:
+    """Return the task list path, honoring ``AXEL_TASK_FILE`` if set."""
+    return Path(os.getenv("AXEL_TASK_FILE", DEFAULT_TASK_FILE)).expanduser()
+
+
+def load_tasks(path: Path | None = None) -> List[Dict]:
+    """Load tasks from a JSON file."""
+    if path is None:
+        path = get_task_file()
+    if not path.exists():
+        return []
+    with path.open() as f:
+        return json.load(f)
+
+
+def add_task(description: str, path: Path | None = None) -> List[Dict]:
+    """Add a task with ``description`` to the JSON database."""
+    if path is None:
+        path = get_task_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tasks = load_tasks(path)
+    next_id = max((t["id"] for t in tasks), default=0) + 1
+    task = {"id": next_id, "description": description, "completed": False}
+    tasks.append(task)
+    path.write_text(json.dumps(tasks, indent=2) + "\n")
+    return tasks
+
+
+def list_tasks(path: Path | None = None) -> List[Dict]:
+    """Return the list of tasks."""
+    return load_tasks(path)
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Simple command-line interface for managing tasks."""
+    parser = argparse.ArgumentParser(description="Manage task list")
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=get_task_file(),
+        help="Path to task database",
+    )
+    sub = parser.add_subparsers(dest="cmd")
+
+    add_p = sub.add_parser("add", help="Add a task")
+    add_p.add_argument("description")
+
+    sub.add_parser("list", help="List tasks")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "add":
+        tasks = add_task(args.description, path=args.path)
+    else:
+        tasks = list_tasks(path=args.path)
+    for task in tasks:
+        print(f"{task['id']} {task['description']}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    main()

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,0 +1,40 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+from axel import add_task, load_tasks  # noqa: E402
+
+
+def test_add_and_load(tmp_path: Path) -> None:
+    file = tmp_path / "tasks.json"
+    add_task("write docs", path=file)
+    assert load_tasks(path=file) == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+
+
+def test_cli_add(tmp_path: Path) -> None:
+    file = tmp_path / "tasks.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "axel.task_manager",
+            "--path",
+            str(file),
+            "add",
+            "write code",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": str(Path(__file__).resolve().parents[1])},
+        check=True,
+    )
+    data = json.loads(file.read_text())
+    assert data == [
+        {"id": 1, "description": "write code", "completed": False},
+    ]
+    assert "1 write code" in result.stdout


### PR DESCRIPTION
what: allow adding tasks via CLI to JSON file
why: track tasks alongside repo list
how to test:
- flake8 axel tests
- pytest --cov=axel --cov=tests

Refs: #50

------
https://chatgpt.com/codex/tasks/task_e_6895924c3078832fb4f14cec7adeb5a6