### PR TITLE
✨ : add utility to strip ANSI codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ For instructions on rotating API tokens see [docs/ROTATING_TOKENS.md](docs/ROTAT
 
 ```python
 from axel import add_repo, list_repos
+from axel.utils import strip_ansi
 
 add_repo("https://github.com/example/repo")
 print(list_repos())
+strip_ansi("\x1b[31merror\x1b[0m")  # -> "error"
 ```
 
 ## discord bot

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -1,0 +1,11 @@
+import re
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    """Return *text* with ANSI escape codes removed.
+
+    Useful when capturing colored CLI output in tests.
+    """
+    return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,6 @@
+from axel.utils import strip_ansi
+
+
+def test_strip_ansi_removes_codes():
+    colored = "\x1b[31merror\x1b[0m"
+    assert strip_ansi(colored) == "error"


### PR DESCRIPTION
what: provide strip_ansi helper with test and docs
why: color codes break string matching in automated checks
how to test: pre-commit run --all-files
Refs: #49

------
https://chatgpt.com/codex/tasks/task_e_68959583dea0832f86cc7c878d228252