### PR TITLE
🐛: trim and validate task descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pre-commit install
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
 8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
+   Descriptions are trimmed and cannot be empty.
 
 ## local setup
 

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -23,10 +23,16 @@ def load_tasks(path: Path | None = None) -> List[Dict]:
 
 
 def add_task(description: str, path: Path | None = None) -> List[Dict]:
-    """Add a task with ``description`` to the JSON database."""
+    """Add a task with ``description`` to the JSON database.
+
+    ``description`` is stripped of surrounding whitespace and must not be empty.
+    """
     if path is None:
         path = get_task_file()
     path.parent.mkdir(parents=True, exist_ok=True)
+    description = description.strip()
+    if not description:
+        raise ValueError("description must not be empty")
     tasks = load_tasks(path)
     next_id = max((t["id"] for t in tasks), default=0) + 1
     task = {"id": next_id, "description": description, "completed": False}

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+import pytest  # noqa: E402
+
 from axel import add_task, load_tasks  # noqa: E402
 
 
@@ -13,6 +15,20 @@ def test_add_and_load(tmp_path: Path) -> None:
     assert load_tasks(path=file) == [
         {"id": 1, "description": "write docs", "completed": False},
     ]
+
+
+def test_add_task_strips_whitespace(tmp_path: Path) -> None:
+    file = tmp_path / "tasks.json"
+    add_task("  write docs  \n", path=file)
+    assert load_tasks(path=file) == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+
+
+def test_add_task_rejects_empty_description(tmp_path: Path) -> None:
+    file = tmp_path / "tasks.json"
+    with pytest.raises(ValueError):
+        add_task("   \n", path=file)
 
 
 def test_cli_add(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- strip surrounding whitespace in add_task
- reject empty task descriptions
- document trimming requirement

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6896cce05930832fb8d83549350a1fd5