### PR TITLE
🐛: enable Discord message intent

### DIFF
--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -40,7 +40,9 @@ def run() -> None:
     token = os.environ.get("DISCORD_BOT_TOKEN")
     if not token:
         raise SystemExit("DISCORD_BOT_TOKEN not set")
-    client = AxelClient(intents=discord.Intents.default())
+    intents = discord.Intents.default()
+    intents.message_content = True
+    client = AxelClient(intents=intents)
     client.run(token)
 
 

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -23,6 +23,10 @@ python -m axel.discord_bot
 This will start the bot using the token set in the `DISCORD_BOT_TOKEN`
 environment variable. Once running, it appears online in the server.
 
+Ensure the **Message Content Intent** is enabled for the bot in the Discord
+Developer Portal so it can read message text. The client enables this intent
+when starting.
+
 ## Usage
 
 Mention the bot in reply to any message you want to save. The bot fetches the

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -69,4 +69,6 @@ def test_run_invokes_client(monkeypatch) -> None:
     db.run()
 
     assert captured["token"] == "123"
-    assert captured["intents"] == discord.Intents.default()
+    intents = captured["intents"]
+    assert isinstance(intents, discord.Intents)
+    assert intents.message_content is True


### PR DESCRIPTION
what: enable Discord client's message_content intent and doc note
why: bot couldn't read message text without this intent
how to test:
- flake8 axel tests
- pytest --cov=axel --cov=tests
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing

Refs: #5

------
https://chatgpt.com/codex/tasks/task_e_6896ccfdd9d4832f9096005b7e51cdde