### PR TITLE
🔧 : keep repo list sorted when adding

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pre-commit install
 1. Add a repo with `python -m axel.repo_manager add <url>` or edit `repos.txt`.
    Lines starting with `#` or with trailing `#` comments are ignored.
    Whitespace around the URL is stripped automatically.
+   The repository list is kept sorted alphabetically.
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -41,6 +41,7 @@ def add_repo(url: str, path: Path | None = None) -> List[str]:
     repos = load_repos(path)
     if url and url not in repos:
         repos.append(url)
+        repos.sort()
         path.write_text("\n".join(repos) + "\n")
     return repos
 

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -87,6 +87,16 @@ def test_add_repo_strips_whitespace(tmp_path: Path) -> None:
     assert load_repos(path=file) == ["https://example.com/repo"]
 
 
+def test_add_repo_keeps_list_sorted(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/b", path=file)
+    add_repo("https://example.com/a", path=file)
+    assert load_repos(path=file) == [
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+
+
 def test_add_repo_creates_parent_dir(tmp_path: Path) -> None:
     file = tmp_path / "nested" / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
## Summary
- ensure add_repo inserts URLs alphabetically
- document that repo list stays sorted

## Testing
- flake8 axel tests
- pytest --cov=gabriel --cov-report=term-missing
- pre-commit run --all-files

Refs: #4

------
https://chatgpt.com/codex/tasks/task_e_6896ccfdd9d4832f9096005b7e51cdde