### PR TITLE
🐛 : silence linkchecker warnings in docs workflow

### DIFF
--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Check links
         run: |
           source .venv/bin/activate
-          linkchecker README.md docs/ || true
+          linkchecker --no-warnings README.md docs/


### PR DESCRIPTION
## Summary
- prevent linkchecker from failing docs job on markdown warning

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6896e9ed8318832fb4b901cce07a1e42