### PR TITLE
Add discord dependency for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 htmlcov/
 pytest_cache/
 local/
+coverage.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pyyaml
 requests
 python-dotenv
 rich
+
+discord.py


### PR DESCRIPTION
## Summary
- ensure discord.py is installed so Discord bot tests run in CI
- ignore coverage.xml generated by tests

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6896e9ed8318832fb4b901cce07a1e42