### PR TITLE
🔧 : normalize repo URLs by stripping trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ pre-commit install
 
 1. Add a repo with `python -m axel.repo_manager add <url>` or edit `repos.txt`.
    Lines starting with `#` or with trailing `#` comments are ignored.
-   Whitespace around the URL is stripped automatically.
+   Whitespace around the URL is stripped automatically and trailing slashes are
+   removed.
    The repository list is kept sorted alphabetically.
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -17,7 +17,10 @@ def get_repo_file() -> Path:
 
 
 def load_repos(path: Path | None = None) -> List[str]:
-    """Load repository URLs from a text file."""
+    """Load repository URLs from a text file.
+
+    Trailing slashes are stripped to keep entries canonical.
+    """
     if path is None:
         path = get_repo_file()
     if not path.exists():
@@ -26,18 +29,21 @@ def load_repos(path: Path | None = None) -> List[str]:
     with path.open() as f:
         for line in f:
             # Allow comments using ``#`` and strip inline notes
-            line = line.split("#", 1)[0].strip()
+            line = line.split("#", 1)[0].strip().rstrip("/")
             if line:
                 repos.append(line)
     return repos
 
 
 def add_repo(url: str, path: Path | None = None) -> List[str]:
-    """Add a repository URL to the list if not already present."""
+    """Add a repository URL to the list if not already present.
+
+    Trailing slashes in ``url`` are removed before processing.
+    """
     if path is None:
         path = get_repo_file()
     path.parent.mkdir(parents=True, exist_ok=True)
-    url = url.strip()
+    url = url.strip().rstrip("/")
     repos = load_repos(path)
     if url and url not in repos:
         repos.append(url)
@@ -47,11 +53,14 @@ def add_repo(url: str, path: Path | None = None) -> List[str]:
 
 
 def remove_repo(url: str, path: Path | None = None) -> List[str]:
-    """Remove a repository URL from the list if present."""
+    """Remove a repository URL from the list if present.
+
+    Trailing slashes in ``url`` are removed before processing.
+    """
     if path is None:
         path = get_repo_file()
     path.parent.mkdir(parents=True, exist_ok=True)
-    url = url.strip()
+    url = url.strip().rstrip("/")
     repos = load_repos(path)
     if url in repos:
         repos.remove(url)

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -87,6 +87,13 @@ def test_add_repo_strips_whitespace(tmp_path: Path) -> None:
     assert load_repos(path=file) == ["https://example.com/repo"]
 
 
+def test_add_repo_strips_trailing_slash(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo/", path=file)
+    add_repo("https://example.com/repo", path=file)
+    assert load_repos(path=file) == ["https://example.com/repo"]
+
+
 def test_add_repo_keeps_list_sorted(tmp_path: Path) -> None:
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/b", path=file)
@@ -114,6 +121,13 @@ def test_remove_repo_strips_whitespace(tmp_path: Path) -> None:
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)
     remove_repo("https://example.com/repo \n", path=file)
+    assert load_repos(path=file) == []
+
+
+def test_remove_repo_strips_trailing_slash(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/repo", path=file)
+    remove_repo("https://example.com/repo/", path=file)
     assert load_repos(path=file) == []
 
 


### PR DESCRIPTION
## Summary
- strip trailing slashes when reading, adding, or removing repos
- document repo URL normalization
- test trailing slash handling in repo manager

## Testing
- `pre-commit run --files axel/repo_manager.py tests/test_repo_manager.py README.md`
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `git ls-files -z | xargs -0 grep -i --line-number --context=1 -e token -e secret -e password`


------
https://chatgpt.com/codex/tasks/task_e_6896ea4477bc832fa223e56c03dd95b2