### PR TITLE
✨ add task completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ pre-commit install
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
 8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
-9. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+9. Mark a task complete with `python -m axel.task_manager complete 1`.
+10. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
 
 ## local setup
 

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -1,7 +1,7 @@
 """axel package."""
 
 from .repo_manager import add_repo, get_repo_file, list_repos, load_repos, remove_repo
-from .task_manager import add_task, get_task_file, list_tasks, load_tasks
+from .task_manager import add_task, complete_task, get_task_file, list_tasks, load_tasks
 
 
 def run_discord_bot() -> None:
@@ -20,6 +20,7 @@ __all__ = [
     "remove_repo",
     "run_discord_bot",
     "add_task",
+    "complete_task",
     "get_task_file",
     "list_tasks",
     "load_tasks",

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -45,6 +45,19 @@ def add_task(description: str, path: Path | None = None) -> List[Dict]:
     return tasks
 
 
+def complete_task(task_id: int, path: Path | None = None) -> List[Dict]:
+    """Mark the task with ``task_id`` as completed."""
+    if path is None:
+        path = get_task_file()
+    tasks = load_tasks(path)
+    for task in tasks:
+        if task["id"] == task_id:
+            task["completed"] = True
+            path.write_text(json.dumps(tasks, indent=2) + "\n")
+            return tasks
+    raise ValueError(f"task id {task_id} not found")
+
+
 def list_tasks(path: Path | None = None) -> List[Dict]:
     """Return the list of tasks."""
     return load_tasks(path)
@@ -66,10 +79,15 @@ def main(argv: List[str] | None = None) -> None:
 
     sub.add_parser("list", help="List tasks")
 
+    complete_p = sub.add_parser("complete", help="Mark a task as completed")
+    complete_p.add_argument("id", type=int)
+
     args = parser.parse_args(argv)
 
     if args.cmd == "add":
         tasks = add_task(args.description, path=args.path)
+    elif args.cmd == "complete":
+        tasks = complete_task(args.id, path=args.path)
     else:
         tasks = list_tasks(path=args.path)
     for task in tasks:


### PR DESCRIPTION
what: support marking tasks complete via CLI.
why: manage task lifecycle within axel.
how to test: flake8 axel tests; pytest --cov=axel --cov=tests;
  pre-commit run --all-files.
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_6896ea4477bc832fa223e56c03dd95b2