### PR TITLE
🩹 : strip cursor ANSI codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ from axel.utils import strip_ansi
 
 add_repo("https://github.com/example/repo")
 print(list_repos())
-strip_ansi("\x1b[31merror\x1b[0m")  # -> "error"
+strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
 ```
 
 ## discord bot

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -1,11 +1,12 @@
 import re
 
-ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
 def strip_ansi(text: str) -> str:
-    """Return *text* with ANSI escape codes removed.
+    """Return *text* with ANSI escape sequences removed.
 
-    Useful when capturing colored CLI output in tests.
+    Removes color codes and other cursor-control sequences, making it
+    useful when capturing CLI output in tests.
     """
     return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,3 +4,9 @@ from axel.utils import strip_ansi
 def test_strip_ansi_removes_codes():
     colored = "\x1b[31merror\x1b[0m"
     assert strip_ansi(colored) == "error"
+
+
+def test_strip_ansi_handles_cursor_codes() -> None:
+    """Non-color ANSI sequences should also be stripped."""
+    text = "\x1b[2Kerror"
+    assert strip_ansi(text) == "error"


### PR DESCRIPTION
## Summary
- widen ANSI regex to drop cursor-control sequences in `strip_ansi`
- document and test stripping of non-color ANSI codes

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6896ea4477bc832fa223e56c03dd95b2