### PR TITLE
🧪 : test load_repos strips trailing slash

### DIFF
--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -74,6 +74,12 @@ def test_load_repos_ignores_comments(tmp_path: Path) -> None:
     ]
 
 
+def test_load_repos_strips_trailing_slash(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    file.write_text("https://example.com/repo/\n")
+    assert load_repos(path=file) == ["https://example.com/repo"]
+
+
 def test_add_repo_no_duplicates(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
## Summary
- add regression test for trailing slash handling in repo_manager.load_repos

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68984aacf1d4832fb106fa2b09e63148