### PR TITLE
fix duplicate repos loaded multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ pre-commit install
    Whitespace around the URL is stripped automatically and trailing slashes are
    removed.
    The repository list is kept sorted alphabetically.
+   Duplicate URLs are automatically removed.
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -19,19 +19,22 @@ def get_repo_file() -> Path:
 def load_repos(path: Path | None = None) -> List[str]:
     """Load repository URLs from a text file.
 
-    Trailing slashes are stripped to keep entries canonical.
+    Trailing slashes are stripped to keep entries canonical and duplicates are
+    removed while preserving order.
     """
     if path is None:
         path = get_repo_file()
     if not path.exists():
         return []
     repos: List[str] = []
+    seen: set[str] = set()
     with path.open() as f:
         for line in f:
             # Allow comments using ``#`` and strip inline notes
             line = line.split("#", 1)[0].strip().rstrip("/")
-            if line:
+            if line and line not in seen:
                 repos.append(line)
+                seen.add(line)
     return repos
 
 

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -80,6 +80,17 @@ def test_load_repos_strips_trailing_slash(tmp_path: Path) -> None:
     assert load_repos(path=file) == ["https://example.com/repo"]
 
 
+def test_load_repos_deduplicates(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    file.write_text(
+        "https://example.com/a\n" "https://example.com/a\n" "https://example.com/b\n"
+    )
+    assert load_repos(path=file) == [
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+
+
 def test_add_repo_no_duplicates(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
what: deduplicate repository URLs and update docs
why: repeated entries could appear after manual edits
how to test:
- pre-commit run --all-files
- flake8 axel tests
- pytest --cov=axel --cov=tests
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_6899150e3158832f880fd88f968c637b