### PR TITLE
🐛: treat non-list task files as empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ pre-commit install
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
 9. Mark a task complete with `python -m axel.task_manager complete 1`.
 10. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+    Axel treats missing, empty, or malformed task files as an empty list.
 
 ## local setup
 

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -13,17 +13,23 @@ def get_task_file() -> Path:
 
 
 def load_tasks(path: Path | None = None) -> List[Dict]:
-    """Load tasks from a JSON file."""
+    """Load tasks from a JSON file.
+
+    Returns an empty list for missing, corrupt, or non-list JSON files.
+    """
     if path is None:
         path = get_task_file()
     if not path.exists():
         return []
     try:
         with path.open() as f:
-            return json.load(f)
+            data = json.load(f)
     except json.JSONDecodeError:
         # Treat empty or corrupt files as no tasks
         return []
+    if not isinstance(data, list):
+        return []
+    return data
 
 
 def add_task(description: str, path: Path | None = None) -> List[Dict]:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -108,3 +108,10 @@ def test_load_tasks_empty_file(tmp_path: Path) -> None:
     file = tmp_path / "tasks.json"
     file.write_text("")
     assert load_tasks(path=file) == []
+
+
+def test_load_tasks_non_list_json(tmp_path: Path) -> None:
+    """Non-list JSON content is treated as no tasks."""
+    file = tmp_path / "tasks.json"
+    file.write_text("{}")
+    assert load_tasks(path=file) == []


### PR DESCRIPTION
## What
- ignore non-list task files
- document task file behavior

## Why
- avoid crashes when tasks.json is malformed

## How to Test
- `python -m pre_commit run --all-files`
- `pytest --cov=axel --cov=tests`

Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_6899150e3158832f880fd88f968c637b