### PR TITLE
Allow strip_ansi to handle byte strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ from axel.utils import strip_ansi
 add_repo("https://github.com/example/repo")
 print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
+strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
 ```
 
 ## discord bot

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -3,10 +3,16 @@ import re
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
-def strip_ansi(text: str) -> str:
+def strip_ansi(text: str | bytes) -> str:
     """Return *text* with ANSI escape sequences removed.
 
-    Removes color codes and other cursor-control sequences, making it
-    useful when capturing CLI output in tests.
+    ``text`` may be a :class:`str` or :class:`bytes` instance. When ``bytes``
+    are provided they are decoded as UTF-8 with ``errors='ignore'`` before
+    stripping the ANSI sequences.
+
+    Removes color codes and other cursor-control sequences, making it useful
+    when capturing CLI output in tests.
     """
+    if isinstance(text, bytes):
+        text = text.decode("utf-8", "ignore")
     return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,3 +10,8 @@ def test_strip_ansi_handles_cursor_codes() -> None:
     """Non-color ANSI sequences should also be stripped."""
     text = "\x1b[2Kerror"
     assert strip_ansi(text) == "error"
+
+
+def test_strip_ansi_accepts_bytes() -> None:
+    """Byte strings should also be handled."""
+    assert strip_ansi(b"\x1b[31merror\x1b[0m") == "error"


### PR DESCRIPTION
## Summary
- allow `strip_ansi` to accept `bytes`
- document byte support in README

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6899150e3158832f880fd88f968c637b