### PR TITLE
🐛 : handle repo URLs case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pre-commit install
    Whitespace around the URL is stripped automatically and trailing slashes are
    removed.
    The repository list is kept sorted alphabetically.
-   Duplicate URLs are automatically removed.
+   Duplicate URLs are automatically removed (case-insensitive).
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -98,10 +98,24 @@ def test_add_repo_no_duplicates(tmp_path: Path):
     assert load_repos(path=file) == ["https://example.com/repo"]
 
 
+def test_add_repo_no_duplicates_case_insensitive(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/Repo", path=file)
+    add_repo("https://example.com/repo", path=file)
+    assert load_repos(path=file) == ["https://example.com/Repo"]
+
+
 def test_add_repo_strips_whitespace(tmp_path: Path) -> None:
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo\n", path=file)
     assert load_repos(path=file) == ["https://example.com/repo"]
+
+
+def test_remove_repo_case_insensitive(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/Repo", path=file)
+    remove_repo("https://example.com/repo", path=file)
+    assert load_repos(path=file) == []
 
 
 def test_add_repo_strips_trailing_slash(tmp_path: Path) -> None:


### PR DESCRIPTION
what: deduplicate and remove repository URLs ignoring case
why: GitHub URLs are case-insensitive; duplicates or removals could misbehave
how to test:
- flake8 axel tests
- pytest --cov=axel --cov=tests
- pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689abae20abc832faad071cd22adf9f9