### PR TITLE
Use absolute imports in package init

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ pre-commit install
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via
    `python -m axel.repo_manager fetch`. Requires ``GH_TOKEN``.
-5. Run `pre-commit run --all-files` before committing to check formatting and tests.
-6. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
-7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
-8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
+5. Import helper functions directly in Python:
+   `from axel.repo_manager import add_repo`.
+6. Run `pre-commit run --all-files` before committing to check formatting and tests.
+7. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
+8. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
+9. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
-9. Mark a task complete with `python -m axel.task_manager complete 1`.
-10. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+10. Mark a task complete with `python -m axel.task_manager complete 1`.
+11. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
 
 ## local setup
 

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -1,13 +1,25 @@
 """axel package."""
 
-from .repo_manager import add_repo, get_repo_file, list_repos, load_repos, remove_repo
-from .task_manager import add_task, complete_task, get_task_file, list_tasks, load_tasks
+from axel.repo_manager import (
+    add_repo,
+    get_repo_file,
+    list_repos,
+    load_repos,
+    remove_repo,
+)
+from axel.task_manager import (
+    add_task,
+    complete_task,
+    get_task_file,
+    list_tasks,
+    load_tasks,
+)
 
 
 def run_discord_bot() -> None:
     """Run the Discord bot without requiring ``discord`` at import time."""
 
-    from .discord_bot import run
+    from axel.discord_bot import run
 
     run()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,13 @@
+def test_init_run_as_script(tmp_path):
+    import os
+    import pathlib
+    import subprocess
+    import sys
+
+    module_path = pathlib.Path("axel/__init__.py")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "."
+    result = subprocess.run(
+        [sys.executable, str(module_path)], capture_output=True, env=env
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- swap relative imports in axel.__init__ for absolute paths
- document importing helpers and add regression test for running __init__ as a script

## Testing
- `npm run lint && npm run test:ci` *(fails: Could not read package.json)*
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689abae20abc832faad071cd22adf9f9