### PR TITLE
🧪 docs: clarify corrupt task file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pre-commit install
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
 9. Mark a task complete with `python -m axel.task_manager complete 1`.
 10. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+11. Empty or invalid `tasks.json` files are treated as containing no tasks.
 
 ## local setup
 

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -13,7 +13,10 @@ def get_task_file() -> Path:
 
 
 def load_tasks(path: Path | None = None) -> List[Dict]:
-    """Load tasks from a JSON file."""
+    """Load tasks from a JSON file.
+
+    Returns an empty list for missing, empty, or invalid JSON files.
+    """
     if path is None:
         path = get_task_file()
     if not path.exists():

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -110,6 +110,13 @@ def test_load_tasks_empty_file(tmp_path: Path) -> None:
     assert load_tasks(path=file) == []
 
 
+def test_load_tasks_invalid_json(tmp_path: Path) -> None:
+    """Corrupt JSON files are treated as having no tasks."""
+    file = tmp_path / "tasks.json"
+    file.write_text("{invalid}")
+    assert load_tasks(path=file) == []
+
+
 def test_load_tasks_default_path(monkeypatch, tmp_path: Path) -> None:
     """``load_tasks`` uses ``AXEL_TASK_FILE`` when no path is provided."""
     file = tmp_path / "tasks.json"


### PR DESCRIPTION
what: document load_tasks handling for invalid JSON files
why: clarify that corrupt task files yield no tasks
how to test: flake8 axel tests && pytest --cov=axel --cov=tests
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689c24103c9c832fae07e025d7f83255