### PR TITLE
✨ : sort repo list case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pre-commit install
    Lines starting with `#` or with trailing `#` comments are ignored.
    Whitespace around the URL is stripped automatically and trailing slashes are
    removed.
-   The repository list is kept sorted alphabetically.
+   The repository list is kept sorted alphabetically, ignoring case.
    Duplicate URLs are automatically removed (case-insensitive).
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -43,7 +43,8 @@ def add_repo(url: str, path: Path | None = None) -> List[str]:
     """Add a repository URL to the list if not already present.
 
     Trailing slashes in ``url`` are removed before processing. Comparison is
-    case-insensitive.
+    case-insensitive. The resulting list is kept sorted alphabetically
+    regardless of case.
     """
     if path is None:
         path = get_repo_file()
@@ -53,7 +54,7 @@ def add_repo(url: str, path: Path | None = None) -> List[str]:
     seen = {r.lower() for r in repos}
     if url and url.lower() not in seen:
         repos.append(url)
-        repos.sort()
+        repos.sort(key=str.lower)
         path.write_text("\n".join(repos) + "\n")
     return repos
 
@@ -110,7 +111,7 @@ def fetch_repo_urls(token: str | None = None) -> List[str]:
             break
         repos.extend(repo["html_url"] for repo in data)
         page += 1
-    repos.sort()
+    repos.sort(key=str.lower)
     return repos
 
 

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -135,6 +135,16 @@ def test_add_repo_keeps_list_sorted(tmp_path: Path) -> None:
     ]
 
 
+def test_add_repo_sorts_case_insensitively(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    add_repo("https://example.com/B", path=file)
+    add_repo("https://example.com/a", path=file)
+    assert load_repos(path=file) == [
+        "https://example.com/a",
+        "https://example.com/B",
+    ]
+
+
 def test_add_repo_creates_parent_dir(tmp_path: Path) -> None:
     file = tmp_path / "nested" / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
what: keep repo list alphabetical regardless of case
why: avoid inconsistent order when URLs vary in case
how to test: flake8 axel tests && pytest --cov=axel --cov=tests
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_689c24103c9c832fae07e025d7f83255