### PR TITLE
🐛 : strip OSC ANSI sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ add_repo("https://github.com/example/repo")
 print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
 strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
+strip_ansi("\x1b]0;title\x07error")  # strips OSC sequences
 ```
 
 ## discord bot

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -1,6 +1,9 @@
 import re
 
-ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+ANSI_ESCAPE_RE = re.compile(
+    "\x1B\\[[0-?]*[ -/]*[@-~]"  # CSI sequences
+    "|\x1B\\][^\x07\x1B]*(?:\x07|\x1B\\\\)"  # OSC sequences
+)
 
 
 def strip_ansi(text: str | bytes) -> str:
@@ -10,8 +13,8 @@ def strip_ansi(text: str | bytes) -> str:
     are provided they are decoded as UTF-8 with ``errors='ignore'`` before
     stripping the ANSI sequences.
 
-    Removes color codes and other cursor-control sequences, making it useful
-    when capturing CLI output in tests.
+    Removes color codes, cursor-control sequences, and operating system
+    commands, making it useful when capturing CLI output in tests.
     """
     if isinstance(text, bytes):
         text = text.decode("utf-8", "ignore")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,12 @@ def test_strip_ansi_handles_cursor_codes() -> None:
     assert strip_ansi(text) == "error"
 
 
+def test_strip_ansi_removes_osc_codes() -> None:
+    """Operating system command sequences should be stripped."""
+    text = "\x1b]0;title\x07error"
+    assert strip_ansi(text) == "error"
+
+
 def test_strip_ansi_accepts_bytes() -> None:
     """Byte strings should also be handled."""
     assert strip_ansi(b"\x1b[31merror\x1b[0m") == "error"


### PR DESCRIPTION
what: allow strip_ansi to remove OSC sequences
why: ensure window title codes don't leak into test output
how: flake8 axel tests && pytest --cov=axel --cov=tests &&
pre-commit run --all-files
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_689c24103c9c832fae07e025d7f83255