### PR TITLE
🩹: handle None in strip_ansi

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ add_repo("https://github.com/example/repo")
 print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
 strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
+strip_ansi(None)  # -> ""
 ```
 
 ## discord bot

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -3,8 +3,11 @@ import re
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
-def strip_ansi(text: str | bytes) -> str:
+def strip_ansi(text: str | bytes | None) -> str:
     """Return *text* with ANSI escape sequences removed.
+
+    Args:
+        text: Text to clean. ``None`` returns an empty string.
 
     ``text`` may be a :class:`str` or :class:`bytes` instance. When ``bytes``
     are provided they are decoded as UTF-8 with ``errors='ignore'`` before
@@ -13,6 +16,8 @@ def strip_ansi(text: str | bytes) -> str:
     Removes color codes and other cursor-control sequences, making it useful
     when capturing CLI output in tests.
     """
+    if text is None:
+        return ""
     if isinstance(text, bytes):
         text = text.decode("utf-8", "ignore")
     return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,3 +15,8 @@ def test_strip_ansi_handles_cursor_codes() -> None:
 def test_strip_ansi_accepts_bytes() -> None:
     """Byte strings should also be handled."""
     assert strip_ansi(b"\x1b[31merror\x1b[0m") == "error"
+
+
+def test_strip_ansi_none_returns_empty() -> None:
+    """Passing ``None`` should return an empty string."""
+    assert strip_ansi(None) == ""


### PR DESCRIPTION
what: support None in strip_ansi and document usage
why: avoid errors when optional text is missing
how to test: flake8 axel tests &&
  pytest --cov=axel --cov=tests &&
  pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689c23fad854832fa41bab110de3b4c2