### PR TITLE
✨ : add --token flag to repo fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pre-commit install
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via
-   `python -m axel.repo_manager fetch`. Requires ``GH_TOKEN``.
+   `python -m axel.repo_manager fetch`. Pass `--token` or set ``GH_TOKEN``.
 5. Run `pre-commit run --all-files` before committing to check formatting and tests.
 6. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -89,7 +89,10 @@ def list_repos(path: Path | None = None) -> List[str]:
 
 
 def fetch_repo_urls(token: str | None = None) -> List[str]:
-    """Fetch repositories for the authenticated user via GitHub API."""
+    """Fetch repositories for the authenticated user via GitHub API.
+
+    The token may be provided directly or read from ``GH_TOKEN``.
+    """
     if token is None:
         token = os.getenv("GH_TOKEN")
     if not token:
@@ -115,7 +118,10 @@ def fetch_repo_urls(token: str | None = None) -> List[str]:
 
 
 def fetch_repos(path: Path | None = None, token: str | None = None) -> List[str]:
-    """Fetch repo URLs and replace the repo list file."""
+    """Fetch repo URLs and replace the repo list file.
+
+    ``token`` overrides ``GH_TOKEN`` when provided.
+    """
     if path is None:
         path = get_repo_file()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -145,7 +151,8 @@ def main(argv: List[str] | None = None) -> None:
     remove_p.add_argument("url")
 
     sub.add_parser("list", help="List repositories")
-    sub.add_parser("fetch", help="Fetch repositories from GitHub")
+    fetch_p = sub.add_parser("fetch", help="Fetch repositories from GitHub")
+    fetch_p.add_argument("--token", help="GitHub token", default=None)
 
     args = parser.parse_args(argv)
 
@@ -154,7 +161,7 @@ def main(argv: List[str] | None = None) -> None:
     elif args.cmd == "remove":
         repos = remove_repo(args.url, path=args.path)
     elif args.cmd == "fetch":
-        repos = fetch_repos(path=args.path)
+        repos = fetch_repos(path=args.path, token=args.token)
     else:
         repos = list_repos(path=args.path)
     for repo in repos:

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -60,7 +60,7 @@ FILES OF INTEREST
 - tests/test_repo_manager.py
 
 REQUIREMENTS
-1. Use the GitHub REST API and authenticate via `GH_TOKEN` env var.
+1. Use the GitHub REST API and authenticate via `GH_TOKEN` env var or `--token` flag.
 2. Add a CLI option `python -m axel.repo_manager fetch` that replaces `repos.txt`
    with the fetched list.
 3. Cover new logic with tests.


### PR DESCRIPTION
Add --token option to python -m axel.repo_manager fetch.
Simplifies fetching repos when GH_TOKEN is unset.

Test: flake8 axel tests && pytest --cov=axel --cov=tests &&
  pre-commit run --all-files
Refs: #0002

------
https://chatgpt.com/codex/tasks/task_e_689c23fad854832fa41bab110de3b4c2