### PR TITLE
🐛 : treat non-list task JSON as empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pre-commit install
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
 9. Mark a task complete with `python -m axel.task_manager complete 1`.
 10. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+11. The task database stores a JSON array; invalid or non-array content loads as empty.
 
 ## local setup
 

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -13,14 +13,20 @@ def get_task_file() -> Path:
 
 
 def load_tasks(path: Path | None = None) -> List[Dict]:
-    """Load tasks from a JSON file."""
+    """Load tasks from a JSON file.
+
+    Returns an empty list when the file is missing, contains invalid JSON or
+    does not decode to a list. This keeps callers from having to handle error
+    cases and guards against accidental corruption of the task database.
+    """
     if path is None:
         path = get_task_file()
     if not path.exists():
         return []
     try:
         with path.open() as f:
-            return json.load(f)
+            data = json.load(f)
+            return data if isinstance(data, list) else []
     except json.JSONDecodeError:
         # Treat empty or corrupt files as no tasks
         return []

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -110,6 +110,13 @@ def test_load_tasks_empty_file(tmp_path: Path) -> None:
     assert load_tasks(path=file) == []
 
 
+def test_load_tasks_non_list(tmp_path: Path) -> None:
+    """Non-list JSON structures load as an empty list."""
+    file = tmp_path / "tasks.json"
+    file.write_text('{"a": 1}')
+    assert load_tasks(path=file) == []
+
+
 def test_load_tasks_default_path(monkeypatch, tmp_path: Path) -> None:
     """``load_tasks`` uses ``AXEL_TASK_FILE`` when no path is provided."""
     file = tmp_path / "tasks.json"


### PR DESCRIPTION
what: ensure load_tasks returns [] for non-list JSON
why: prevent errors when tasks.json contains an object
how to test: pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689c23fad854832fa41bab110de3b4c2