### PR TITLE
✨ : – add task removal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ pre-commit install
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
 8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
-9. Mark a task complete with `python -m axel.task_manager complete 1`.
-10. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+9. Remove a task with `python -m axel.task_manager remove 1`.
+10. Mark a task complete with `python -m axel.task_manager complete 1`.
+11. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
 
 ## local setup
 

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -1,7 +1,14 @@
 """axel package."""
 
 from .repo_manager import add_repo, get_repo_file, list_repos, load_repos, remove_repo
-from .task_manager import add_task, complete_task, get_task_file, list_tasks, load_tasks
+from .task_manager import (
+    add_task,
+    complete_task,
+    get_task_file,
+    list_tasks,
+    load_tasks,
+    remove_task,
+)
 from .utils import strip_ansi
 
 
@@ -26,4 +33,5 @@ __all__ = [
     "get_task_file",
     "list_tasks",
     "load_tasks",
+    "remove_task",
 ]

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -58,6 +58,18 @@ def complete_task(task_id: int, path: Path | None = None) -> List[Dict]:
     raise ValueError(f"task id {task_id} not found")
 
 
+def remove_task(task_id: int, path: Path | None = None) -> List[Dict]:
+    """Remove the task with ``task_id`` from the JSON database."""
+    if path is None:
+        path = get_task_file()
+    tasks = load_tasks(path)
+    new_tasks = [t for t in tasks if t["id"] != task_id]
+    if len(new_tasks) == len(tasks):
+        raise ValueError(f"task id {task_id} not found")
+    path.write_text(json.dumps(new_tasks, indent=2) + "\n")
+    return new_tasks
+
+
 def list_tasks(path: Path | None = None) -> List[Dict]:
     """Return the list of tasks."""
     return load_tasks(path)
@@ -82,12 +94,17 @@ def main(argv: List[str] | None = None) -> None:
     complete_p = sub.add_parser("complete", help="Mark a task as completed")
     complete_p.add_argument("id", type=int)
 
+    remove_p = sub.add_parser("remove", help="Remove a task")
+    remove_p.add_argument("id", type=int)
+
     args = parser.parse_args(argv)
 
     if args.cmd == "add":
         tasks = add_task(args.description, path=args.path)
     elif args.cmd == "complete":
         tasks = complete_task(args.id, path=args.path)
+    elif args.cmd == "remove":
+        tasks = remove_task(args.id, path=args.path)
     else:
         tasks = list_tasks(path=args.path)
     for task in tasks:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -6,7 +6,13 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
 import pytest  # noqa: E402
 
-from axel import add_task, complete_task, list_tasks, load_tasks  # noqa: E402
+from axel import (  # noqa: E402
+    add_task,
+    complete_task,
+    list_tasks,
+    load_tasks,
+    remove_task,
+)
 
 
 def test_add_and_load(tmp_path: Path) -> None:
@@ -40,6 +46,23 @@ def test_complete_task(tmp_path: Path) -> None:
         {"id": 1, "description": "write docs", "completed": True},
         {"id": 2, "description": "write code", "completed": False},
     ]
+
+
+def test_remove_task(tmp_path: Path) -> None:
+    file = tmp_path / "tasks.json"
+    add_task("write docs", path=file)
+    add_task("write code", path=file)
+    remove_task(1, path=file)
+    assert load_tasks(path=file) == [
+        {"id": 2, "description": "write code", "completed": False},
+    ]
+
+
+def test_remove_task_missing_id(tmp_path: Path) -> None:
+    file = tmp_path / "tasks.json"
+    add_task("write docs", path=file)
+    with pytest.raises(ValueError):
+        remove_task(2, path=file)
 
 
 def test_cli_add(tmp_path: Path) -> None:
@@ -93,6 +116,46 @@ def test_cli_complete(tmp_path: Path) -> None:
     assert "1 write docs" in result.stdout
 
 
+def test_cli_remove(tmp_path: Path) -> None:
+    file = tmp_path / "tasks.json"
+    add_task("write docs", path=file)
+    add_task("write code", path=file)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "axel.task_manager",
+            "--path",
+            str(file),
+            "remove",
+            "1",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": str(Path(__file__).resolve().parents[1])},
+        check=True,
+    )
+    data = json.loads(file.read_text())
+    assert data == [
+        {"id": 2, "description": "write code", "completed": False},
+    ]
+    assert "2 write code" in result.stdout
+
+
+def test_main_remove(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    file = tmp_path / "tasks.json"
+    add_task("write docs", path=file)
+    add_task("write code", path=file)
+    from axel.task_manager import main
+
+    main(["--path", str(file), "remove", "1"])
+    assert load_tasks(path=file) == [
+        {"id": 2, "description": "write code", "completed": False},
+    ]
+    assert "2 write code" in capsys.readouterr().out
+
+
 def test_env_default_var(monkeypatch, tmp_path: Path) -> None:
     """``AXEL_TASK_FILE`` controls the default task file."""
     task_file = tmp_path / "tasks.json"
@@ -129,6 +192,20 @@ def test_complete_task_default_path(monkeypatch, tmp_path: Path) -> None:
     tm.complete_task(1)
     assert tm.load_tasks() == [
         {"id": 1, "description": "write docs", "completed": True},
+    ]
+
+
+def test_remove_task_default_path(monkeypatch, tmp_path: Path) -> None:
+    """``remove_task`` honors ``AXEL_TASK_FILE`` when ``path`` is omitted."""
+    file = tmp_path / "tasks.json"
+    monkeypatch.setenv("AXEL_TASK_FILE", str(file))
+    import axel.task_manager as tm
+
+    tm.add_task("write docs")
+    tm.add_task("write code")
+    tm.remove_task(1)
+    assert tm.load_tasks() == [
+        {"id": 2, "description": "write code", "completed": False},
     ]
 
 


### PR DESCRIPTION
what: add remove_task API and CLI subcommand; cover default path and CLI branch
why: allow deleting tasks and keep test coverage at 100%
how to test: flake8 axel tests; pytest --cov=axel --cov=tests --cov-report term-missing; pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689c2418866c832f85f428aad74473b2