### PR TITLE
📝 : fix prompts codex spelling

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -69,7 +69,7 @@ REQUIREMENTS
 
 ACCEPTANCE CHECK
 Running `python -m axel.repo_manager fetch` writes the repository URLs to
-`repos.txt` and tests reflect the new behaviour.
+`repos.txt` and tests reflect the new behavior.
 
 OUTPUT
 Return only the necessary patch.


### PR DESCRIPTION
## Summary
- fix British spelling in prompts codex docs

## Testing
- `codespell README.md docs/`
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d59cd78f4832fa79842f36c208640