### PR TITLE
✨: validate strip_ansi input types

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
 strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
 strip_ansi(None)  # -> ""
+strip_ansi(123)  # raises TypeError for invalid types
 ```
 
 ## discord bot

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -11,7 +11,7 @@ def strip_ansi(text: str | bytes | None) -> str:
 
     ``text`` may be a :class:`str` or :class:`bytes` instance. When ``bytes``
     are provided they are decoded as UTF-8 with ``errors='ignore'`` before
-    stripping the ANSI sequences.
+    stripping the ANSI sequences. Passing any other type raises ``TypeError``.
 
     Removes color codes and other cursor-control sequences, making it useful
     when capturing CLI output in tests.
@@ -20,4 +20,6 @@ def strip_ansi(text: str | bytes | None) -> str:
         return ""
     if isinstance(text, bytes):
         text = text.decode("utf-8", "ignore")
+    elif not isinstance(text, str):
+        raise TypeError("text must be str, bytes, or None")
     return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from axel import strip_ansi
 
 
@@ -20,3 +22,9 @@ def test_strip_ansi_accepts_bytes() -> None:
 def test_strip_ansi_none_returns_empty() -> None:
     """Passing ``None`` should return an empty string."""
     assert strip_ansi(None) == ""
+
+
+def test_strip_ansi_invalid_type_raises() -> None:
+    """Non-string inputs should raise ``TypeError``."""
+    with pytest.raises(TypeError):
+        strip_ansi(123)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- raise TypeError on non-str/bytes strip_ansi inputs
- document and test invalid type behavior

## Testing
- `python -m flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `python -m pre_commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d59def768832fb51bd418efe41def