### PR TITLE
Add env override for Discord bot save directory

### DIFF
--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -10,13 +10,20 @@ import discord
 SAVE_DIR = Path("local/discord")
 
 
+def _get_save_dir() -> Path:
+    env = os.getenv("AXEL_DISCORD_DIR")
+    return Path(env) if env else SAVE_DIR
+
+
 def save_message(message: discord.Message) -> Path:
     """Persist the provided message as markdown.
 
-    Ensures the save directory exists before writing.
+    Ensures the save directory exists before writing. The directory can be overridden
+    via the ``AXEL_DISCORD_DIR`` environment variable.
     """
-    SAVE_DIR.mkdir(parents=True, exist_ok=True)
-    path = SAVE_DIR / f"{message.id}.md"
+    save_dir = _get_save_dir()
+    save_dir.mkdir(parents=True, exist_ok=True)
+    path = save_dir / f"{message.id}.md"
     timestamp = message.created_at.isoformat()
     content = f"# {message.author.display_name}\n\n{timestamp}\n\n{message.content}\n"
     path.write_text(content)

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -35,6 +35,12 @@ original message and writes a markdown file under
 doesn't exist. Each file records the author's display name, an ISO 8601
 timestamp, and the message content.
 
+Set the ``AXEL_DISCORD_DIR`` environment variable to change the save location:
+
+```bash
+export AXEL_DISCORD_DIR=/path/to/notes
+```
+
 Future iterations can analyze these notes alongside `token.place` and
 [`gabriel`](https://github.com/futuroptimist/gabriel) to suggest quests across
 repositories.

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -44,6 +44,14 @@ def test_save_message_creates_dir(tmp_path: Path) -> None:
     assert missing.exists()
 
 
+def test_save_message_respects_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AXEL_DISCORD_DIR", str(tmp_path))
+    msg = DummyMessage("hey", mid=3)
+    path = db.save_message(msg)
+    assert path.parent == tmp_path
+    assert path.read_text() == "# user\n\n2024-01-01T00:00:00+00:00\n\nhey\n"
+
+
 def test_run_missing_token(monkeypatch) -> None:
     """``run`` exits if ``DISCORD_BOT_TOKEN`` is not set."""
     monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)


### PR DESCRIPTION
## Summary
- allow Discord bot to save messages to a custom directory via AXEL_DISCORD_DIR

## Testing
- `python -m flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `python -m pre_commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d59def768832fb51bd418efe41def