### PR TITLE
✨ : show completion status in task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ pre-commit install
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
 8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
+   Listings show `[ ]` for pending tasks and `[x]` when completed.
 9. Remove a task with `python -m axel.task_manager remove 1`.
 10. Mark a task complete with `python -m axel.task_manager complete 1`.
 11. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -111,7 +111,8 @@ def main(argv: List[str] | None = None) -> None:
     else:
         tasks = list_tasks(path=args.path)
     for task in tasks:
-        print(f"{task['id']} {task['description']}")
+        status = "[x]" if task["completed"] else "[ ]"
+        print(f"{task['id']} {status} {task['description']}")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual use

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -87,7 +87,7 @@ def test_cli_add(tmp_path: Path) -> None:
     assert data == [
         {"id": 1, "description": "write code", "completed": False},
     ]
-    assert "1 write code" in result.stdout
+    assert "1 [ ] write code" in result.stdout
 
 
 def test_cli_complete(tmp_path: Path) -> None:
@@ -113,7 +113,7 @@ def test_cli_complete(tmp_path: Path) -> None:
     assert data == [
         {"id": 1, "description": "write docs", "completed": True},
     ]
-    assert "1 write docs" in result.stdout
+    assert "1 [x] write docs" in result.stdout
 
 
 def test_cli_remove(tmp_path: Path) -> None:
@@ -140,7 +140,7 @@ def test_cli_remove(tmp_path: Path) -> None:
     assert data == [
         {"id": 2, "description": "write code", "completed": False},
     ]
-    assert "2 write code" in result.stdout
+    assert "2 [ ] write code" in result.stdout
 
 
 def test_main_remove(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -153,7 +153,7 @@ def test_main_remove(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None
     assert load_tasks(path=file) == [
         {"id": 2, "description": "write code", "completed": False},
     ]
-    assert "2 write code" in capsys.readouterr().out
+    assert "2 [ ] write code" in capsys.readouterr().out
 
 
 def test_env_default_var(monkeypatch, tmp_path: Path) -> None:
@@ -239,8 +239,8 @@ def test_main_branches(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> No
     import axel.task_manager as tm
 
     tm.main(["--path", str(file), "add", "write docs"])
-    assert "1 write docs" in capsys.readouterr().out
+    assert "1 [ ] write docs" in capsys.readouterr().out
     tm.main(["--path", str(file), "complete", "1"])
-    assert "1 write docs" in capsys.readouterr().out
+    assert "1 [x] write docs" in capsys.readouterr().out
     tm.main(["--path", str(file), "list"])
-    assert "1 write docs" in capsys.readouterr().out
+    assert "1 [x] write docs" in capsys.readouterr().out


### PR DESCRIPTION
Display [ ] or [x] for tasks when listing via CLI.
Helps track progress without opening tasks.json.
Test: flake8 axel tests &&
  pytest --cov=axel --cov=tests &&
  pre-commit run --all-files
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_689d59def768832fb51bd418efe41def