### PR TITLE
✨ Preserve Unicode task descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ pre-commit install
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
 8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
+   Descriptions may include Unicode characters and are stored unescaped using
+   UTF-8 for readability.
 9. Remove a task with `python -m axel.task_manager remove 1`.
 10. Mark a task complete with `python -m axel.task_manager complete 1`.
 11. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -22,7 +22,7 @@ def load_tasks(path: Path | None = None) -> List[Dict]:
     if not path.exists():
         return []
     try:
-        with path.open() as f:
+        with path.open(encoding="utf-8") as f:
             return json.load(f)
     except json.JSONDecodeError:
         # Treat empty or corrupt files as no tasks
@@ -44,7 +44,10 @@ def add_task(description: str, path: Path | None = None) -> List[Dict]:
     next_id = max((t["id"] for t in tasks), default=0) + 1
     task = {"id": next_id, "description": description, "completed": False}
     tasks.append(task)
-    path.write_text(json.dumps(tasks, indent=2) + "\n")
+    path.write_text(
+        json.dumps(tasks, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
     return tasks
 
 
@@ -56,7 +59,10 @@ def complete_task(task_id: int, path: Path | None = None) -> List[Dict]:
     for task in tasks:
         if task["id"] == task_id:
             task["completed"] = True
-            path.write_text(json.dumps(tasks, indent=2) + "\n")
+            path.write_text(
+                json.dumps(tasks, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
             return tasks
     raise ValueError(f"task id {task_id} not found")
 
@@ -69,7 +75,10 @@ def remove_task(task_id: int, path: Path | None = None) -> List[Dict]:
     new_tasks = [t for t in tasks if t["id"] != task_id]
     if len(new_tasks) == len(tasks):
         raise ValueError(f"task id {task_id} not found")
-    path.write_text(json.dumps(new_tasks, indent=2) + "\n")
+    path.write_text(
+        json.dumps(new_tasks, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
     return new_tasks
 
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -31,6 +31,15 @@ def test_add_task_strips_whitespace(tmp_path: Path) -> None:
     ]
 
 
+def test_add_task_preserves_unicode(tmp_path: Path) -> None:
+    """Unicode descriptions are stored without escapes."""
+    file = tmp_path / "tasks.json"
+    add_task("español café", path=file)
+    text = file.read_text(encoding="utf-8")
+    assert "español café" in text
+    assert "\\u" not in text
+
+
 def test_add_task_rejects_empty_description(tmp_path: Path) -> None:
     file = tmp_path / "tasks.json"
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- store task data in UTF-8 without escaping Unicode
- test Unicode persistence in tasks
- document UTF-8 task support

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689d59def768832fb51bd418efe41def