### PR TITLE
Run pre-commit in lint workflow

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -15,10 +15,8 @@ jobs:
           uv venv .venv
           source .venv/bin/activate
           uv pip install -r requirements.txt
-          uv pip install flake8 black isort
-      - name: Run linters
+          uv pip install pre-commit
+      - name: Run pre-commit
         run: |
           source .venv/bin/activate
-          flake8 axel tests
-          isort --check-only axel tests
-          black --check axel tests
+          pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,4 @@ repos:
         entry: pytest --cov=axel --cov=tests --cov-report=xml
         language: system
         pass_filenames: false
+        stages: [manual]


### PR DESCRIPTION
## Summary
- run `pre-commit` in lint workflow to ensure required linters are installed
- limit test hook to manual stage to avoid duplicate runs

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d59b3a878832fb05ab2503b5691dc