### PR TITLE
🐛 : – skip inaccessible repos in hillclimb

### DIFF
--- a/.axel/hillclimb/scripts/axel.py
+++ b/.axel/hillclimb/scripts/axel.py
@@ -208,7 +208,11 @@ def cmd_hillclimb(args):
     for r in targets:
         slug = r["slug"]
         default_branch = r.get("default_branch", "main")
-        repo_dir = ensure_clone(slug, default_branch)
+        try:
+            repo_dir = ensure_clone(slug, default_branch)
+        except RuntimeError as e:
+            print(f"Skipping {slug}: {e}")
+            continue
 
         for attempt in range(1, args.runs + 1):
             branch = make_branch_name(cfg["branch_prefix"], slug, card["key"], attempt)

--- a/docs/HILLCLIMB.md
+++ b/docs/HILLCLIMB.md
@@ -21,6 +21,8 @@ Configure
 
 .axel/hillclimb/cards/*.yml: action cards (acceptance criteria + constraints).
 
+If a repo is missing or private, it is skipped with a log message instead of aborting the run.
+
 .env: set GITHUB_TOKEN= (see .env.example).
 
 Notes

--- a/tests/test_hillclimb_skip.py
+++ b/tests/test_hillclimb_skip.py
@@ -1,0 +1,58 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "hillclimb", ".axel/hillclimb/scripts/axel.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skips_inaccessible_repo(monkeypatch, tmp_path, capsys):
+    hc = load_module()
+
+    def fake_load_yaml(path):
+        if path == hc.CONFIG:
+            return {
+                "branch_prefix": "hc",
+                "touch_budget": {"files_max": 1, "loc_max": 1},
+                "labels": [],
+                "pr": {},
+            }
+        if path == hc.REPOS:
+            return {
+                "repos": [
+                    {
+                        "slug": "missing/repo",
+                        "default_branch": "main",
+                        "enabled": True,
+                    }
+                ]
+            }
+        if Path(path).name == "card.yml":
+            return {"key": "test", "acceptance_criteria": []}
+        return {}
+
+    card_dir = tmp_path / "cards"
+    card_dir.mkdir()
+    (card_dir / "card.yml").write_text("key: test\nacceptance_criteria: []\n")
+
+    monkeypatch.setattr(hc, "CARDS_DIR", card_dir)
+    monkeypatch.setattr(hc, "load_yaml", fake_load_yaml)
+    monkeypatch.setattr(hc, "load_dotenv", lambda: None)
+    monkeypatch.setattr(
+        hc,
+        "ensure_clone",
+        lambda slug, default_branch: (
+            _ for _ in ()
+        ).throw(RuntimeError("clone failed")),
+    )
+
+    args = SimpleNamespace(runs=1, card=None, execute=False)
+    hc.cmd_hillclimb(args)
+    out = capsys.readouterr().out
+    assert "Skipping missing/repo" in out


### PR DESCRIPTION
what: handle missing repos in hillclimb, add test and docs
why: scheduled hillclimb workflow failed when repo clone aborted
how to test:
- flake8 axel tests
- pytest --cov=axel --cov=tests
- pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d59b3a878832fb05ab2503b5691dc