### PR TITLE
fix: strip OSC ANSI sequences

### DIFF
--- a/axel/utils.py
+++ b/axel/utils.py
@@ -1,6 +1,16 @@
 import re
 
-ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+ANSI_ESCAPE_RE = re.compile(
+    r"""
+    \x1B  # ESC
+    (
+        \[[0-?]*[ -/]*[@-~]        # CSI sequences
+        |
+        \].*?(?:\x07|\x1B\\)    # OSC sequences, terminated by BEL or ESC\\
+    )
+    """,
+    re.VERBOSE,
+)
 
 
 def strip_ansi(text: str | bytes | None) -> str:
@@ -13,8 +23,8 @@ def strip_ansi(text: str | bytes | None) -> str:
     are provided they are decoded as UTF-8 with ``errors='ignore'`` before
     stripping the ANSI sequences.
 
-    Removes color codes and other cursor-control sequences, making it useful
-    when capturing CLI output in tests.
+    Removes color, cursor-control, and OSC hyperlink sequences, making it
+    useful when capturing CLI output in tests.
     """
     if text is None:
         return ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,12 @@ def test_strip_ansi_handles_cursor_codes() -> None:
     assert strip_ansi(text) == "error"
 
 
+def test_strip_ansi_strips_osc_sequences() -> None:
+    """OSC hyperlinks must be removed."""
+    text = "\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\"
+    assert strip_ansi(text) == "link"
+
+
 def test_strip_ansi_accepts_bytes() -> None:
     """Byte strings should also be handled."""
     assert strip_ansi(b"\x1b[31merror\x1b[0m") == "error"


### PR DESCRIPTION
## Summary
- extend `strip_ansi` to remove OSC hyperlink sequences
- add regression test for OSC sequences

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d59b3a878832fb05ab2503b5691dc