### PR TITLE
✨ : – handle bytearray in strip_ansi

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ add_repo("https://github.com/example/repo")
 print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
 strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
+strip_ansi(bytearray(b"\x1b[31merror\x1b[0m"))  # bytearrays too
 strip_ansi(None)  # -> ""
 ```
 

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -3,21 +3,21 @@ import re
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
-def strip_ansi(text: str | bytes | None) -> str:
+def strip_ansi(text: str | bytes | bytearray | None) -> str:
     """Return *text* with ANSI escape sequences removed.
 
     Args:
         text: Text to clean. ``None`` returns an empty string.
 
-    ``text`` may be a :class:`str` or :class:`bytes` instance. When ``bytes``
-    are provided they are decoded as UTF-8 with ``errors='ignore'`` before
-    stripping the ANSI sequences.
+    ``text`` may be a :class:`str`, :class:`bytes`, or :class:`bytearray` instance.
+    When bytes-like input is provided it is decoded as UTF-8 with ``errors='ignore'``
+    before stripping the ANSI sequences.
 
     Removes color codes and other cursor-control sequences, making it useful
     when capturing CLI output in tests.
     """
     if text is None:
         return ""
-    if isinstance(text, bytes):
-        text = text.decode("utf-8", "ignore")
+    if isinstance(text, (bytes, bytearray)):
+        text = bytes(text).decode("utf-8", "ignore")
     return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,12 @@ def test_strip_ansi_accepts_bytes() -> None:
     assert strip_ansi(b"\x1b[31merror\x1b[0m") == "error"
 
 
+def test_strip_ansi_accepts_bytearray() -> None:
+    """Bytearrays should also be handled."""
+    data = bytearray(b"\x1b[31merror\x1b[0m")
+    assert strip_ansi(data) == "error"
+
+
 def test_strip_ansi_none_returns_empty() -> None:
     """Passing ``None`` should return an empty string."""
     assert strip_ansi(None) == ""


### PR DESCRIPTION
Adds bytearray handling to strip_ansi for broader bytes-like support.

Test: flake8 axel tests
Test: pytest --cov=axel --cov=tests
Test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d59d37e84832f90409893af6d9c2e