### PR TITLE
🐛 : – handle non-list task files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pre-commit install
 9. Remove a task with `python -m axel.task_manager remove 1`.
 10. Mark a task complete with `python -m axel.task_manager complete 1`.
 11. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
-12. Empty or invalid `tasks.json` files are treated as containing no tasks.
+12. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
 
 ## local setup
 

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -14,8 +14,7 @@ def get_task_file() -> Path:
 
 def load_tasks(path: Path | None = None) -> List[Dict]:
     """Load tasks from a JSON file.
-
-    Returns an empty list for missing, empty, or invalid JSON files.
+    Returns an empty list for missing, empty, invalid, or non-list JSON files.
     """
     if path is None:
         path = get_task_file()
@@ -23,10 +22,13 @@ def load_tasks(path: Path | None = None) -> List[Dict]:
         return []
     try:
         with path.open() as f:
-            return json.load(f)
+            data = json.load(f)
     except json.JSONDecodeError:
         # Treat empty or corrupt files as no tasks
         return []
+    if not isinstance(data, list):
+        return []
+    return data
 
 
 def add_task(description: str, path: Path | None = None) -> List[Dict]:

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -180,6 +180,13 @@ def test_load_tasks_invalid_json(tmp_path: Path) -> None:
     assert load_tasks(path=file) == []
 
 
+def test_load_tasks_non_list_json(tmp_path: Path) -> None:
+    """Non-list JSON files are treated as having no tasks."""
+    file = tmp_path / "tasks.json"
+    file.write_text('{"id": 1}')
+    assert load_tasks(path=file) == []
+
+
 def test_load_tasks_default_path(monkeypatch, tmp_path: Path) -> None:
     """``load_tasks`` uses ``AXEL_TASK_FILE`` when no path is provided."""
     file = tmp_path / "tasks.json"


### PR DESCRIPTION
what: guard against non-list task JSON
why: keep task loading robust
how to test: python -m flake8 axel tests && pytest --cov=axel --cov=tests

------
https://chatgpt.com/codex/tasks/task_e_689d59d37e84832f90409893af6d9c2e