### PR TITLE
🐛 : – require scheme for repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ pre-commit install
 
 ## usage
 
-1. Add a repo with `python -m axel.repo_manager add <url>` or edit `repos.txt`.
+1. Add a repo with `python -m axel.repo_manager add <url>` (use `https://...`).
+   Alternatively, edit `repos.txt`.
    Lines starting with `#` or with trailing `#` comments are ignored.
    Whitespace around the URL is stripped automatically and trailing slashes are
    removed.

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -42,14 +42,18 @@ def load_repos(path: Path | None = None) -> List[str]:
 def add_repo(url: str, path: Path | None = None) -> List[str]:
     """Add a repository URL to the list if not already present.
 
-    Trailing slashes in ``url`` are removed before processing. Comparison is
-    case-insensitive. The resulting list is kept sorted alphabetically
-    regardless of case.
+    ``url`` must include the scheme (for example ``https://``). Trailing slashes
+    in ``url`` are removed before processing. Comparison is case-insensitive. The
+    resulting list is kept sorted alphabetically regardless of case.
     """
     if path is None:
         path = get_repo_file()
     path.parent.mkdir(parents=True, exist_ok=True)
     url = url.strip().rstrip("/")
+    if "://" not in url:
+        raise ValueError(
+            "url must include scheme, e.g., 'https://github.com/user/repo'"
+        )
     repos = load_repos(path)
     seen = {r.lower() for r in repos}
     if url and url.lower() not in seen:

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -151,6 +151,12 @@ def test_add_repo_creates_parent_dir(tmp_path: Path) -> None:
     assert file.read_text() == "https://example.com/repo\n"
 
 
+def test_add_repo_requires_scheme(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    with pytest.raises(ValueError):
+        add_repo("github.com/u/repo", path=file)
+
+
 def test_remove_repo_missing(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
what: validate repo URLs include scheme and document requirement
why: avoid adding malformed entries
how to test: flake8 axel tests; pytest --cov=axel --cov=tests; pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_689eb50576e8832fab0b5d4644b7d6d4