### PR TITLE
🔧: support GITHUB_TOKEN fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ pre-commit install
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via
-   `python -m axel.repo_manager fetch`. Pass `--token` or set ``GH_TOKEN``.
+   `python -m axel.repo_manager fetch`. Pass `--token` or set ``GH_TOKEN``
+   or ``GITHUB_TOKEN``.
 5. Run `pre-commit run --all-files` before committing to check formatting and tests.
 6. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -92,12 +92,13 @@ def list_repos(path: Path | None = None) -> List[str]:
 def fetch_repo_urls(token: str | None = None) -> List[str]:
     """Fetch repositories for the authenticated user via GitHub API.
 
-    The token may be provided directly or read from ``GH_TOKEN``.
+    The token may be provided directly or read from ``GH_TOKEN`` or
+    ``GITHUB_TOKEN``.
     """
     if token is None:
-        token = os.getenv("GH_TOKEN")
+        token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
     if not token:
-        raise RuntimeError("GH_TOKEN is required to fetch repositories")
+        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required to fetch repositories")
     headers = {"Authorization": f"token {token}"}
     page = 1
     repos: List[str] = []
@@ -121,7 +122,7 @@ def fetch_repo_urls(token: str | None = None) -> List[str]:
 def fetch_repos(path: Path | None = None, token: str | None = None) -> List[str]:
     """Fetch repo URLs and replace the repo list file.
 
-    ``token`` overrides ``GH_TOKEN`` when provided.
+    ``token`` overrides ``GH_TOKEN`` or ``GITHUB_TOKEN`` when provided.
     """
     if path is None:
         path = get_repo_file()

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -60,7 +60,8 @@ FILES OF INTEREST
 - tests/test_repo_manager.py
 
 REQUIREMENTS
-1. Use the GitHub REST API and authenticate via `GH_TOKEN` env var or `--token` flag.
+1. Use the GitHub REST API and authenticate via `GH_TOKEN`/`GITHUB_TOKEN`
+   env var or `--token` flag.
 2. Add a CLI option `python -m axel.repo_manager fetch` that replaces `repos.txt`
    with the fetched list.
 3. Cover new logic with tests.

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -382,6 +382,7 @@ def test_cli_fetch_accepts_token_flag(monkeypatch, tmp_path: Path, capsys) -> No
         return Resp([])
 
     monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setattr(requests, "get", fake_get)
     from axel import repo_manager as rm
 
@@ -395,12 +396,36 @@ def test_cli_fetch_accepts_token_flag(monkeypatch, tmp_path: Path, capsys) -> No
 
 
 def test_fetch_repo_urls_requires_token(monkeypatch) -> None:
-    """Fetching without ``GH_TOKEN`` raises an error."""
+    """Fetching without ``GH_TOKEN``/``GITHUB_TOKEN`` raises an error."""
     monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     from axel import repo_manager as rm
 
     with pytest.raises(RuntimeError):
         rm.fetch_repo_urls()
+
+
+def test_fetch_repo_urls_accepts_github_token(monkeypatch) -> None:
+    """``GITHUB_TOKEN`` is accepted when ``GH_TOKEN`` is absent."""
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    def fake_get(url, headers=None, params=None, timeout=0):
+        assert headers["Authorization"] == "token token"
+
+        class Resp:
+            def json(self):
+                return []
+
+            def raise_for_status(self):
+                return None
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    from axel import repo_manager as rm
+
+    assert rm.fetch_repo_urls() == []
 
 
 def test_fetch_repos_defaults(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
what: allow repo_manager to use GITHUB_TOKEN env var
why: GH workflows expose GITHUB_TOKEN; repo_manager now honors it
how to test: flake8 axel tests; pytest --cov=axel --cov=tests; pre-commit run --all-files
Refs: #2

------
https://chatgpt.com/codex/tasks/task_e_689eb50576e8832fab0b5d4644b7d6d4