### PR TITLE
✨: support bytearray in strip_ansi

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ add_repo("https://github.com/example/repo")
 print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
 strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
+strip_ansi(bytearray(b"\x1b[31merror\x1b[0m"))  # bytearrays are accepted
 strip_ansi(None)  # -> ""
 strip_ansi(123)  # raises TypeError for invalid types
 ```

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -3,23 +3,24 @@ import re
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
-def strip_ansi(text: str | bytes | None) -> str:
+def strip_ansi(text: str | bytes | bytearray | None) -> str:
     """Return *text* with ANSI escape sequences removed.
 
     Args:
         text: Text to clean. ``None`` returns an empty string.
 
-    ``text`` may be a :class:`str` or :class:`bytes` instance. When ``bytes``
-    are provided they are decoded as UTF-8 with ``errors='ignore'`` before
-    stripping the ANSI sequences. Passing any other type raises ``TypeError``.
+    ``text`` may be a :class:`str`, :class:`bytes` or :class:`bytearray`
+    instance. When bytes-like objects are provided they are decoded as UTF-8
+    with ``errors='ignore'`` before stripping the ANSI sequences. Passing any
+    other type raises ``TypeError``.
 
     Removes color codes and other cursor-control sequences, making it useful
     when capturing CLI output in tests.
     """
     if text is None:
         return ""
-    if isinstance(text, bytes):
-        text = text.decode("utf-8", "ignore")
+    if isinstance(text, (bytes, bytearray)):
+        text = bytes(text).decode("utf-8", "ignore")
     elif not isinstance(text, str):
-        raise TypeError("text must be str, bytes, or None")
+        raise TypeError("text must be str, bytes, bytearray, or None")
     return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils_bytearray.py
+++ b/tests/test_utils_bytearray.py
@@ -1,0 +1,6 @@
+from axel import strip_ansi
+
+
+def test_strip_ansi_accepts_bytearray() -> None:
+    """Bytearray inputs should also be handled."""
+    assert strip_ansi(bytearray(b"\x1b[31merror\x1b[0m")) == "error"


### PR DESCRIPTION
## What
- allow strip_ansi to accept bytearray inputs
- document bytearray usage
- test strip_ansi with bytearray input

## Why
- extend utility to bytes-like objects

## How to Test
- `pre-commit run --all-files --show-diff-on-failure`
- `pytest --cov=axel --cov=tests`


------
https://chatgpt.com/codex/tasks/task_e_689f88ed1f44832fbe296bf9b0dd1bcb