### PR TITLE
✨ Expand AXEL_DISCORD_DIR home-path support

### DIFF
--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -11,8 +11,12 @@ SAVE_DIR = Path("local/discord")
 
 
 def _get_save_dir() -> Path:
+    """Return directory for saving Discord messages.
+
+    Honors ``AXEL_DISCORD_DIR`` and expands ``~`` to the user's home.
+    """
     env = os.getenv("AXEL_DISCORD_DIR")
-    return Path(env) if env else SAVE_DIR
+    return Path(env).expanduser() if env else SAVE_DIR
 
 
 def save_message(message: discord.Message) -> Path:

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -41,6 +41,8 @@ Set the ``AXEL_DISCORD_DIR`` environment variable to change the save location:
 export AXEL_DISCORD_DIR=/path/to/notes
 ```
 
+Paths beginning with ``~`` are expanded to the user's home directory.
+
 Future iterations can analyze these notes alongside `token.place` and
 [`gabriel`](https://github.com/futuroptimist/gabriel) to suggest quests across
 repositories.

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -52,6 +52,15 @@ def test_save_message_respects_env(tmp_path: Path, monkeypatch) -> None:
     assert path.read_text() == "# user\n\n2024-01-01T00:00:00+00:00\n\nhey\n"
 
 
+def test_save_message_env_expands_user(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AXEL_DISCORD_DIR", "~/discord")
+    msg = DummyMessage("home", mid=4)
+    path = db.save_message(msg)
+    assert path.parent == tmp_path / "discord"
+    assert path.read_text() == "# user\n\n2024-01-01T00:00:00+00:00\n\nhome\n"
+
+
 def test_run_missing_token(monkeypatch) -> None:
     """``run`` exits if ``DISCORD_BOT_TOKEN`` is not set."""
     monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)


### PR DESCRIPTION
what: expand AXEL_DISCORD_DIR to honor ~ and document behavior
why: allow discord notes to live in home-relative paths
how: flake8 axel tests && pytest --cov=axel --cov=tests && pre-commit run --all-files
Refs: #5

------
https://chatgpt.com/codex/tasks/task_e_68a00d3e4bc0832f9c179d7d5018065d