### PR TITLE
✨ : – support memoryview in strip_ansi

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
 strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
 strip_ansi(bytearray(b"\x1b[31merror\x1b[0m"))  # bytearrays are accepted
+strip_ansi(memoryview(b"\x1b[31merror\x1b[0m"))  # memoryviews are accepted
 strip_ansi(None)  # -> ""
 strip_ansi(123)  # raises TypeError for invalid types
 ```

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -3,24 +3,24 @@ import re
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
-def strip_ansi(text: str | bytes | bytearray | None) -> str:
+def strip_ansi(text: str | bytes | bytearray | memoryview | None) -> str:
     """Return *text* with ANSI escape sequences removed.
 
     Args:
         text: Text to clean. ``None`` returns an empty string.
 
-    ``text`` may be a :class:`str`, :class:`bytes` or :class:`bytearray`
-    instance. When bytes-like objects are provided they are decoded as UTF-8
-    with ``errors='ignore'`` before stripping the ANSI sequences. Passing any
-    other type raises ``TypeError``.
+    ``text`` may be a :class:`str`, :class:`bytes`, :class:`bytearray` or
+    :class:`memoryview` instance. When bytes-like objects are provided they are
+    decoded as UTF-8 with ``errors='ignore'`` before stripping the ANSI
+    sequences. Passing any other type raises ``TypeError``.
 
     Removes color codes and other cursor-control sequences, making it useful
     when capturing CLI output in tests.
     """
     if text is None:
         return ""
-    if isinstance(text, (bytes, bytearray)):
+    if isinstance(text, (bytes, bytearray, memoryview)):
         text = bytes(text).decode("utf-8", "ignore")
     elif not isinstance(text, str):
-        raise TypeError("text must be str, bytes, bytearray, or None")
+        raise TypeError("text must be str, bytes, bytearray, memoryview, or None")
     return ANSI_ESCAPE_RE.sub("", text)

--- a/tests/test_utils_memoryview.py
+++ b/tests/test_utils_memoryview.py
@@ -1,0 +1,6 @@
+from axel import strip_ansi
+
+
+def test_strip_ansi_accepts_memoryview() -> None:
+    """Memoryview inputs should also be handled."""
+    assert strip_ansi(memoryview(b"\x1b[31merror\x1b[0m")) == "error"


### PR DESCRIPTION
what: allow strip_ansi to accept memoryview
why: memoryview is a common bytes-like type
how to test: pre-commit run --all-files --hook-stage manual
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a00d3e4bc0832f9c179d7d5018065d