### PR TITLE
🧪 docs: document AXEL_TASK_FILE usage and test default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ control.
 
 Start with `examples/local/repos_example.txt` when creating your private repo list.
 
+To store tasks privately, point `AXEL_TASK_FILE` to a file under `local/`:
+
+```bash
+python -m axel.task_manager add "write docs" --path local/tasks.json
+export AXEL_TASK_FILE=local/tasks.json
+```
+
 ## privacy & transparency
 
 Axel treats your goals with respect. Repository lists and any Discord notes

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -225,6 +225,18 @@ def test_remove_task_default_path(monkeypatch, tmp_path: Path) -> None:
     ]
 
 
+def test_list_tasks_default_path(monkeypatch, tmp_path: Path) -> None:
+    """``list_tasks`` honors ``AXEL_TASK_FILE`` when ``path`` is omitted."""
+    file = tmp_path / "tasks.json"
+    monkeypatch.setenv("AXEL_TASK_FILE", str(file))
+    import axel.task_manager as tm
+
+    tm.add_task("write docs")
+    assert tm.list_tasks() == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+
+
 def test_complete_task_missing_id(tmp_path: Path) -> None:
     """Completing an unknown task id raises ``ValueError``."""
     file = tmp_path / "tasks.json"


### PR DESCRIPTION
what: document AXEL_TASK_FILE usage and test list_tasks default path
why: clarify private task storage and ensure env var coverage
how: flake8 axel tests && pytest --cov=axel --cov=tests && pre-commit run --all-files --show-diff-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68a00d3e4bc0832f9c179d7d5018065d