### PR TITLE
📝 docs: consolidate hillclimb prompts

### DIFF
--- a/.axel/hillclimb/prompts/code.md
+++ b/.axel/hillclimb/prompts/code.md
@@ -1,6 +1,0 @@
-Implement the PLANNER plan. Rules:
-- Respect touch budget (files_max, loc_max). If exceeded, STOP and return.
-- Only modify files listed by the planner unless strictly necessary.
-- Update docs/tests alongside code.
-- No secrets or hard-coded tokens.
-- Output a unified diff and list of commands to run tests.

--- a/.axel/hillclimb/prompts/critique.md
+++ b/.axel/hillclimb/prompts/critique.md
@@ -1,5 +1,0 @@
-Self-review:
-- Does the diff meet acceptance_criteria? If not, say why and STOP.
-- Are lints/tests likely to pass? Note failures with file:line refs.
-- Any security/perf regressions? If yes, propose a smaller alternative.
-Conclude with PASS or REVISE and a brief rationale.

--- a/.axel/hillclimb/prompts/plan.md
+++ b/.axel/hillclimb/prompts/plan.md
@@ -1,8 +1,0 @@
-You are a senior maintainer planning a smallest-viable change to satisfy an ACTION CARD.
-Output:
-1) Minimal plan satisfying acceptance_criteria and constraints.
-2) Exact file list to add/change, each with 1–2 line rationale.
-3) Risks (API/security/perf) + mitigations.
-4) Test plan (commands + cases).
-5) Checklist the coder must satisfy.
-Respect the touch budget. Prefer smallest possible change that passes CI.

--- a/docs/HILLCLIMB.md
+++ b/docs/HILLCLIMB.md
@@ -1,7 +1,10 @@
 <!-- BEGIN: AXEL HILLCLIMB -->
 # Axel Hillclimb Mode
 
-**What it does:** Given an action card, Axel clones matching repos, creates N branches, and seeds each with an `AXEL_TASK.md` containing planner/coder/critique prompts and acceptance criteria. By default it’s a dry run. With `--execute`, it pushes branches and opens **draft** PRs so CI and humans can iterate safely.
+**What it does:** Given an action card, Axel clones matching repos, creates N branches, and seeds each
+with an `AXEL_TASK.md` containing planner/coder/critique prompts and acceptance criteria. The prompts
+are documented in [prompts/prompts-hillclimb.md](prompts/prompts-hillclimb.md). By default it’s a dry
+run. With `--execute`, it pushes branches and opens **draft** PRs so CI and humans can iterate safely.
 
 ## Quickstart
 ```bash
@@ -20,6 +23,7 @@ Configure
 .axel/hillclimb/config.yml: runs, touch budgets, labels, selection mode.
 
 .axel/hillclimb/cards/*.yml: action cards (acceptance criteria + constraints).
+See [example action cards](prompts/prompts-hillclimb.md#example-action-cards).
 
 .env: set GITHUB_TOKEN= (see .env.example).
 

--- a/docs/prompts/prompts-hillclimb.md
+++ b/docs/prompts/prompts-hillclimb.md
@@ -1,0 +1,79 @@
+---
+title: 'Hillclimb Prompts'
+slug: 'prompts-hillclimb'
+---
+
+# Hillclimb Prompts
+
+Combined planner, coder and critique prompts used by Axel's hillclimb mode.
+
+## Plan Prompt
+
+```text
+You are a senior maintainer planning a smallest-viable change to satisfy an ACTION CARD.
+Output:
+1) Minimal plan satisfying acceptance_criteria and constraints.
+2) Exact file list to add/change, each with 1–2 line rationale.
+3) Risks (API/security/perf) + mitigations.
+4) Test plan (commands + cases).
+5) Checklist the coder must satisfy.
+Respect the touch budget. Prefer smallest possible change that passes CI.
+```
+
+## Code Prompt
+
+```text
+Implement the PLANNER plan. Rules:
+- Respect touch budget (files_max, loc_max). If exceeded, STOP and return.
+- Only modify files listed by the planner unless strictly necessary.
+- Update docs/tests alongside code.
+- Avoid committing credentials or hard-coded API keys.
+- Output a unified diff and list of commands to run tests.
+```
+
+## Critique Prompt
+
+```text
+Self-review:
+- Does the diff meet acceptance_criteria? If not, say why and STOP.
+- Are lints/tests likely to pass? Note failures with file:line refs.
+- Any security/perf regressions? If yes, propose a smaller alternative.
+Conclude with PASS or REVISE and a brief rationale.
+```
+
+## Example Action Cards
+
+```yaml
+# add-pipx-install.yml
+key: add-pipx-install
+title: Add 1-click pipx install + Quickstart
+applies_to: ["f2clipboard", "gitshelves"]
+acceptance_criteria:
+  - "Published to PyPI with pinned deps"
+  - "README top includes 60s Quickstart using pipx"
+  - "CI publishes on tag v*"
+constraints:
+  files_max: 6
+  loc_max: 200
+must_pass:
+  - "pytest -q"
+  - "ruff --version || true"
+```
+
+```yaml
+# docker-compose-mock.yml
+key: docker-compose-mock
+title: One-command docker compose (relay + server + mock LLM)
+applies_to: ["token.place"]
+acceptance_criteria:
+  - "docker compose up works with no config"
+  - "README Quickstart (<=60s) shows compose path"
+  - "Release notes mention compose; image published on tag"
+constraints:
+  files_max: 8
+  loc_max: 250
+must_pass:
+  - "docker --version"
+```
+
+More cards live in `.axel/hillclimb/cards/`.


### PR DESCRIPTION
## Summary
- move hillclimb planner/coder/critique prompts into docs
- link hillclimb guide to the new prompts file
- show working example action cards for clarity

## Testing
- `pre-commit run --all-files`
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68a00d0878e8832f98b6879d133d8f71