### PR TITLE
🐛: keep repo list sorted after removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ pre-commit install
    Lines starting with `#` or with trailing `#` comments are ignored.
    Whitespace around the URL is stripped automatically and trailing slashes are
    removed.
-   The repository list is kept sorted alphabetically, ignoring case.
-   Duplicate URLs are automatically removed (case-insensitive).
+   The repository list is kept sorted alphabetically, ignoring case. Removing entries
+   preserves this order. Duplicate URLs are automatically removed (case-insensitive).
 2. View the list with `python -m axel.repo_manager list`.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -67,7 +67,8 @@ def remove_repo(url: str, path: Path | None = None) -> List[str]:
     """Remove a repository URL from the list if present.
 
     Trailing slashes in ``url`` are removed before processing and comparison is
-    case-insensitive.
+    case-insensitive. The remaining list is kept sorted alphabetically,
+    ignoring case.
     """
     if path is None:
         path = get_repo_file()
@@ -81,6 +82,7 @@ def remove_repo(url: str, path: Path | None = None) -> List[str]:
             removed = True
             break
     if removed:
+        repos.sort(key=str.lower)
         text = "\n".join(repos)
         if text:
             text += "\n"

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -178,6 +178,18 @@ def test_remove_repo_strips_trailing_slash(tmp_path: Path) -> None:
     assert load_repos(path=file) == []
 
 
+def test_remove_repo_sorts_remaining(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    file.write_text(
+        "https://example.com/b\nhttps://example.com/a\nhttps://example.com/c\n"
+    )
+    remove_repo("https://example.com/c", path=file)
+    assert load_repos(path=file) == [
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+
+
 def test_env_default_var(monkeypatch, tmp_path: Path):
     repo_file = tmp_path / "repos.txt"
     monkeypatch.setenv("AXEL_REPO_FILE", str(repo_file))


### PR DESCRIPTION
what: sort remaining repos after removing and document behavior
why: maintain alphabetical order even if file was unsorted
how: flake8 axel tests
how: pytest --cov=axel --cov=tests
how: pre-commit run --all-files
Refs: #0004

------
https://chatgpt.com/codex/tasks/task_e_68a57c49bb08832f9e1f2101496a3d5d