### PR TITLE
🧱 : add cube model and STL build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: install hillclimb hillclimb-execute
+.PHONY: install hillclimb hillclimb-execute test
 install:
 	python -m pip install -r requirements.txt
 hillclimb:
 	python .axel/hillclimb/scripts/axel.py hillclimb --runs 4 --dry-run
 hillclimb-execute:
 	python .axel/hillclimb/scripts/axel.py hillclimb --runs 4 --execute
+test:
+	pytest --cov=axel --cov=tests

--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ the [`blog`](https://github.com/futuroptimist/blog) for publishing progress,
 and [`esp.ac`](https://github.com/futuroptimist/esp.ac), a simple landing page
 for Esp.
 
+## hardware
+
+OpenSCAD source files live in `hardware/cad`. Run `bash scripts/build_stl.sh`
+to regenerate matching files in `hardware/stl`.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on sending pull requests.
 This project adheres to the [Code of Conduct](CODE_OF_CONDUCT.md).
 For LLM-specific tips see [AGENTS.md](AGENTS.md).

--- a/hardware/cad/cube.scad
+++ b/hardware/cad/cube.scad
@@ -1,0 +1,2 @@
+// Simple cube model for demonstration
+cube([10, 10, 10]);

--- a/hardware/stl/cube.stl
+++ b/hardware/stl/cube.stl
@@ -1,0 +1,86 @@
+solid OpenSCAD_Model
+  facet normal -0 0 1
+    outer loop
+      vertex 0 10 10
+      vertex 10 0 10
+      vertex 10 10 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 0 10
+      vertex 0 10 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 10 10 0
+      vertex 10 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10 10 0
+      vertex 0 0 0
+      vertex 0 10 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 10 0 10
+      vertex 0 0 10
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 10 0 10
+      vertex 0 0 0
+      vertex 10 0 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10 0 10
+      vertex 10 10 0
+      vertex 10 10 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 10 0
+      vertex 10 0 10
+      vertex 10 0 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 10 10 0
+      vertex 0 10 10
+      vertex 10 10 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 10 10
+      vertex 10 10 0
+      vertex 0 10 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 10 10
+      vertex 0 10 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 10 10
+      vertex 0 0 0
+      vertex 0 0 10
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/scripts/build_stl.sh
+++ b/scripts/build_stl.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CAD_DIR="hardware/cad"
+STL_DIR="hardware/stl"
+mkdir -p "$STL_DIR"
+
+for scad in "$CAD_DIR"/*.scad; do
+  [ -e "$scad" ] || continue
+  base=$(basename "$scad" .scad)
+  openscad -o "$STL_DIR/$base.stl" "$scad"
+  echo "Generated $STL_DIR/$base.stl"
+done


### PR DESCRIPTION
## Summary
- add cube OpenSCAD source and build script
- generate matching STL and note hardware workflow in docs
- provide make test target for running test suite

## Testing
- `bash scripts/build_stl.sh`
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a811c784f8832f81fcdc2c610fe0d3