### PR TITLE
Add pipx quickstart and release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+      - name: Build
+        run: |
+          uv build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ and generate actionable quests.
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/axel/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/axel/actions/workflows/03-docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/axel)](LICENSE)
 
+## 60s Quickstart
+
+```bash
+pipx install axel
+axel-repo list
+```
+
+`pipx` installs axel with pinned deps. `axel-repo` manages repo lists; use
+`axel-task` for tasks.
+
 ## roadmap
 - [x] maintain a list of repos in `repos.txt`
 - [x] simple CLI for managing repos (`python -m axel.repo_manager`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ readme = "README.md"
 authors = [{ name = "futuroptimist" }]
 license = { text = "MIT" }
 requires-python = ">=3.11"
-dependencies = ["requests"]
+dependencies = ["requests==2.31.0"]
+
+[project.scripts]
+axel-repo = "axel.repo_manager:main"
+axel-task = "axel.task_manager:main"
 
 [project.urls]
 Homepage = "https://github.com/futuroptimist/axel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml
-requests
+requests==2.31.0
 python-dotenv
 rich
 pytest


### PR DESCRIPTION
what: document pipx install, pin deps, add PyPI publish workflow
why: enable 1-click install and auto release on tag
how to test:
- ruff --version
- flake8 axel tests
- pre-commit run --files README.md
- pytest --cov=axel --cov=tests
- pytest -q
Refs: #add-pipx-install

------
https://chatgpt.com/codex/tasks/task_e_68a811afeb90832f849509064f007bef