### PR TITLE
feat: add clear command to task manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ pre-commit install
    Listings show `[ ]` for pending tasks and `[x]` when completed.
 9. Remove a task with `python -m axel.task_manager remove 1`.
 10. Mark a task complete with `python -m axel.task_manager complete 1`.
-11. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
-12. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
+11. Clear all tasks with `python -m axel.task_manager clear`.
+12. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+13. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
 
 ## local setup
 

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -3,6 +3,7 @@
 from .repo_manager import add_repo, get_repo_file, list_repos, load_repos, remove_repo
 from .task_manager import (
     add_task,
+    clear_tasks,
     complete_task,
     get_task_file,
     list_tasks,
@@ -34,4 +35,5 @@ __all__ = [
     "list_tasks",
     "load_tasks",
     "remove_task",
+    "clear_tasks",
 ]

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -90,6 +90,15 @@ def list_tasks(path: Path | None = None) -> List[Dict]:
     return load_tasks(path)
 
 
+def clear_tasks(path: Path | None = None) -> List[Dict]:
+    """Remove all tasks from the JSON database."""
+    if path is None:
+        path = get_task_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[]\n", encoding="utf-8")
+    return []
+
+
 def main(argv: List[str] | None = None) -> None:
     """Simple command-line interface for managing tasks."""
     parser = argparse.ArgumentParser(description="Manage task list")
@@ -112,6 +121,8 @@ def main(argv: List[str] | None = None) -> None:
     remove_p = sub.add_parser("remove", help="Remove a task")
     remove_p.add_argument("id", type=int)
 
+    sub.add_parser("clear", help="Remove all tasks")
+
     args = parser.parse_args(argv)
 
     if args.cmd == "add":
@@ -120,6 +131,8 @@ def main(argv: List[str] | None = None) -> None:
         tasks = complete_task(args.id, path=args.path)
     elif args.cmd == "remove":
         tasks = remove_task(args.id, path=args.path)
+    elif args.cmd == "clear":
+        tasks = clear_tasks(path=args.path)
     else:
         tasks = list_tasks(path=args.path)
     for task in tasks:


### PR DESCRIPTION
what: add clear_tasks function and CLI command to wipe tasks
why: allow quick reset of task list
how to test: pre-commit run --all-files && pytest --cov=axel --cov=tests
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_68a8117c1cfc832faffbd88dfa0f8d79