### PR TITLE
🐛: sort loaded repos case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ pre-commit install
    removed.
    The repository list is kept sorted alphabetically, ignoring case. Removing entries
    preserves this order. Duplicate URLs are automatically removed (case-insensitive).
-2. View the list with `python -m axel.repo_manager list`.
+2. View the list with `python -m axel.repo_manager list`. Output is sorted
+   alphabetically, ignoring case.
 3. Remove a repo with `python -m axel.repo_manager remove <url>`.
 4. Replace `repos.txt` with the authenticated user's repos via
    `python -m axel.repo_manager fetch`. Pass `--token` or set ``GH_TOKEN`` or

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -20,7 +20,8 @@ def load_repos(path: Path | None = None) -> List[str]:
     """Load repository URLs from a text file.
 
     Trailing slashes are stripped to keep entries canonical and duplicates are
-    removed case-insensitively while preserving the first occurrence.
+    removed case-insensitively while preserving the first occurrence's case.
+    The resulting list is sorted alphabetically, ignoring case.
     """
     if path is None:
         path = get_repo_file()
@@ -36,6 +37,7 @@ def load_repos(path: Path | None = None) -> List[str]:
             if line and key not in seen:
                 repos.append(line)
                 seen.add(key)
+    repos.sort(key=str.lower)
     return repos
 
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -4,3 +4,4 @@
 
 - add `docker-compose-mock.yml` for one-command stack (server, relay, mock LLM)
   and publish Docker images on tag
+- ensure `load_repos` returns entries sorted alphabetically

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -91,6 +91,15 @@ def test_load_repos_deduplicates(tmp_path: Path) -> None:
     ]
 
 
+def test_load_repos_sorts_entries(tmp_path: Path) -> None:
+    file = tmp_path / "repos.txt"
+    file.write_text("https://example.com/b\nhttps://example.com/a\n")
+    assert load_repos(path=file) == [
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+
+
 def test_add_repo_no_duplicates(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)


### PR DESCRIPTION
what: sort repository list on load; add test; document behavior
why: manual edits could make list output unordered
how to test: flake8 axel tests; pytest --cov=axel --cov=tests
pre-commit run --all-files
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_68a92cce3004832fac44f2353266a857