### PR TITLE
📝 : – mark Discord bot issue tasks complete

### DIFF
--- a/issues/0005-discord-bot-ingest.md
+++ b/issues/0005-discord-bot-ingest.md
@@ -5,7 +5,7 @@ the bot downloads the parent message and stores it under `local/discord/`.
 This keeps any notes private while making them accessible to axel for
 future LLM-powered quests.
 
-- [ ] create `axel.discord_bot` module
-- [ ] document workflow in `docs/discord-bot.md`
-- [ ] update roadmap with this feature
+- [x] create `axel.discord_bot` module
+- [x] document workflow in `docs/discord-bot.md`
+- [x] update roadmap with this feature
 - [ ] explore integrations with `token.place` and `gabriel`


### PR DESCRIPTION
What: update issue 0005 checkboxes for finished Discord bot work.
Why: keep task tracking in sync with existing bot module and docs.
How to test:
- pre-commit run --all-files
- flake8 axel tests
- pytest --cov=axel --cov=tests
Refs: #0005

------
https://chatgpt.com/codex/tasks/task_e_68a92cce3004832fac44f2353266a857