### PR TITLE
📝 : – clarify Git ignore phrasing in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ pytest --cov=axel --cov=tests
 - Set `AXEL_REPO_FILE` for a custom repo list
 - Keep the [roadmap](README.md#roadmap) updated
 - Suggest quests that link multiple projects from `repos.txt`
-- Document private notes in `local/` (gitignored)
+- Document private notes in `local/` (ignored by Git)
 - Scan for secrets with the command in `README.md` before publishing
 - Integrate `token.place` clients and coordinate with [gabriel](https://github.com/futuroptimist/gabriel)
 - Use [`futuroptimist/flywheel`](https://github.com/futuroptimist/flywheel) when starting new repositories to

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This launches the token.place server, relay and a mock LLM using one command.
 - [x] represent personal flywheel of projects and highlight cross-pollination (see repo list below)
 - [x] document workflow for a private `local/` directory (see local setup below)
 - [x] track tasks with markdown files in the `issues/` folder
-- [x] verify `local/` directories are gitignored (see `.gitignore`)
+- [x] verify `local/` directories are ignored by Git (see `.gitignore`)
 - [x] add `THREAT_MODEL.md` with cross-repo considerations (see `docs/THREAT_MODEL.md`)
 - [x] provide token rotation guidance in docs (see `docs/ROTATING_TOKENS.md`)
 - [x] adopt [`flywheel`](https://github.com/futuroptimist/flywheel) template for new repositories
@@ -84,7 +84,7 @@ pre-commit install
 ## local setup
 
 To keep personal notes and repo lists private, set `AXEL_REPO_FILE` to a path
-under `local/`, which is gitignored. The repo manager creates the directory
+under `local/`, which is ignored by Git. The repo manager creates the directory
 automatically if it doesn't already exist. Paths beginning with `~` expand to
 the user's home directory.
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -3,7 +3,7 @@
 Axel coordinates multiple repositories and stores user notes locally. This document summarizes security considerations shared by [gabriel](https://github.com/futuroptimist/gabriel).
 
 - Secrets such as API keys should be stored in environment variables or encrypted files, never committed to source control.
-- The `local/` directory is gitignored by default. Verify this with `git check-ignore -v local/` after setup.
+- The `local/` directory is ignored by Git by default. Verify this with `git check-ignore -v local/` after setup.
 - When using `token.place` or `gabriel`, review their permissions and rotate tokens regularly. See [docs/ROTATING_TOKENS.md](ROTATING_TOKENS.md) for detailed steps.
 - Notes saved under `local/discord/` stay on your machine. Future work may encrypt these files.
 - Before publishing the repository, scan for accidental secrets with:

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -11,7 +11,7 @@ that ingests messages from your server.
   information.
 - When the bot is mentioned in a reply, download the parent message and store a
   local copy for future reference.
-- Persist messages under `local/discord/` which is gitignored by default.
+- Persist messages under `local/discord/`, which is ignored by Git by default.
 
 ## Launching the Bot
 


### PR DESCRIPTION
what: clarify "gitignored" phrasing in README and docs
why: improve clarity and conform to standard language
how to test:
- `codespell README.md docs/ -I dict/allow.txt`
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a53f710832facc8e7d7f1b1b7d5