### PR TITLE
✨ : – strip OSC sequences from strip_ansi

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ from axel import add_repo, list_repos, strip_ansi
 add_repo("https://github.com/example/repo")
 print(list_repos())
 strip_ansi("\x1b[2K\x1b[31merror\x1b[0m")  # -> "error"
+strip_ansi("\x1b]0;title\x07error")  # OSC sequences removed -> "error"
 strip_ansi(b"\x1b[31merror\x1b[0m")  # bytes are accepted
 strip_ansi(bytearray(b"\x1b[31merror\x1b[0m"))  # bytearrays are accepted
 strip_ansi(memoryview(b"\x1b[31merror\x1b[0m"))  # memoryviews are accepted

--- a/axel/utils.py
+++ b/axel/utils.py
@@ -1,6 +1,14 @@
 import re
 
-ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+ANSI_ESCAPE_RE = re.compile(
+    r"""
+    \x1B(?:
+        \[[0-?]*[ -/]*[@-~]      # CSI sequences
+      | \][^\x1B\x07]*(?:\x07|\x1B\\)  # OSC sequences
+    )
+    """,
+    re.VERBOSE,
+)
 
 
 def strip_ansi(text: str | bytes | bytearray | memoryview | None) -> str:
@@ -14,8 +22,8 @@ def strip_ansi(text: str | bytes | bytearray | memoryview | None) -> str:
     decoded as UTF-8 with ``errors='ignore'`` before stripping the ANSI
     sequences. Passing any other type raises ``TypeError``.
 
-    Removes color codes and other cursor-control sequences, making it useful
-    when capturing CLI output in tests.
+    Removes color codes, cursor-control sequences, and OSC commands, making it
+    useful when capturing CLI output in tests.
     """
     if text is None:
         return ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,9 @@ def test_strip_ansi_invalid_type_raises() -> None:
     """Non-string inputs should raise ``TypeError``."""
     with pytest.raises(TypeError):
         strip_ansi(123)  # type: ignore[arg-type]
+
+
+def test_strip_ansi_removes_osc_sequences() -> None:
+    """OSC sequences like ``ESC]0;`` should be stripped."""
+    text = "\x1b]0;title\x07error"
+    assert strip_ansi(text) == "error"


### PR DESCRIPTION
## Summary
- expand strip_ansi regex to drop OSC sequences
- document OSC handling and add unit test

## Testing
- `git ls-files -z | xargs -0 grep -i --line-number --context=1 -e token -e secret -e password`
- `git diff --cached | python scripts/scan-secrets.py`
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --files axel/utils.py tests/test_utils.py README.md`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a2ebf04832fadaf09bbdde8d276