### PR TITLE
🔐 : detect API keys in secret scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Before flipping this repository to public, search the codebase for accidental cr
 A quick sanity check is:
 
 ```bash
-git ls-files -z | xargs -0 grep -i --line-number --context=1 -e token -e secret -e password
+git ls-files -z | xargs -0 grep -i --line-number --context=1 \
+  -e token -e secret -e password -e api_key -e api-key
 ```
 
 Review the output and remove any sensitive data. Make sure `repos.txt` contains only repositories you wish to share.
@@ -159,7 +160,8 @@ For staged changes, run:
 git diff --cached | python scripts/scan-secrets.py
 ```
 
-This helper flags suspicious lines in the diff before they reach the commit history.
+This helper flags suspicious lines containing keywords like "token", "secret",
+"password", or "api key" in the diff before they reach the commit history.
 
 The repos in `repos.txt` come from various projects like
 [`dspace`](https://github.com/democratizedspace/dspace) and

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -2,13 +2,13 @@
 """Scan stdin for potential secrets.
 
 Reads text from standard input and searches for keywords commonly used in
-credentials like "token", "secret", or "password". If any matches are found,
-messages are printed to stderr and the script exits with status 1.
+credentials like "token", "secret", "password", or "api_key". If any matches
+are found, messages are printed to stderr and the script exits with status 1.
 """
 import re
 import sys
 
-PATTERN = re.compile(r"(token|secret|password)", re.IGNORECASE)
+PATTERN = re.compile(r"(token|secret|password|api[_-]?key)", re.IGNORECASE)
 
 
 def main() -> int:

--- a/tests/test_scan_secrets.py
+++ b/tests/test_scan_secrets.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
 
+import pytest
+
 
 def run_scan(data: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -21,3 +23,10 @@ def test_allows_safe_text() -> None:
     result = run_scan("hello world")
     assert result.returncode == 0
     assert result.stderr == ""
+
+
+@pytest.mark.parametrize("var", ["apikey", "api_key", "api-key"])
+def test_detects_api_keys(var: str) -> None:
+    result = run_scan(f"{var}=123")
+    assert result.returncode == 1
+    assert var in result.stderr.lower()


### PR DESCRIPTION
What: extend scan-secrets for api_key detection and doc
Why: prevent accidental API key leaks
How to test: pre-commit run --all-files && pytest --cov=axel --cov=tests
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa9a2ebf04832fadaf09bbdde8d276