### PR TITLE
chore: configure git user for hillclimb workflow

### DIFF
--- a/.github/workflows/axel-hillclimb.yml
+++ b/.github/workflows/axel-hillclimb.yml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
       - run: python -m pip install -r requirements.txt
+      - name: Configure git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Hillclimb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- configure git user and email so hillclimb can commit to cloned repos

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a3d6b00832fb984286b932f2678