### PR TITLE
🐛: handle missing hillclimb prompts

### DIFF
--- a/.axel/hillclimb/prompts/code.md
+++ b/.axel/hillclimb/prompts/code.md
@@ -1,0 +1,6 @@
+Implement the PLANNER plan. Rules:
+- Respect touch budget (files_max, loc_max). If exceeded, STOP and return.
+- Only modify files listed by the planner unless strictly necessary.
+- Update docs/tests alongside code.
+- Avoid committing credentials or hard-coded API keys.
+- Output a unified diff and list of commands to run tests.

--- a/.axel/hillclimb/prompts/critique.md
+++ b/.axel/hillclimb/prompts/critique.md
@@ -1,0 +1,5 @@
+Self-review:
+- Does the diff meet acceptance_criteria? If not, say why and STOP.
+- Are lints/tests likely to pass? Note failures with file:line refs.
+- Any security/perf regressions? If yes, propose a smaller alternative.
+Conclude with PASS or REVISE and a brief rationale.

--- a/.axel/hillclimb/prompts/plan.md
+++ b/.axel/hillclimb/prompts/plan.md
@@ -1,0 +1,8 @@
+You are a senior maintainer planning a smallest-viable change to satisfy an ACTION CARD.
+Output:
+1) Minimal plan satisfying acceptance_criteria and constraints.
+2) Exact file list to add/change, each with 1–2 line rationale.
+3) Risks (API/security/perf) + mitigations.
+4) Test plan (commands + cases).
+5) Checklist the coder must satisfy.
+Respect the touch budget. Prefer smallest possible change that passes CI.

--- a/.axel/hillclimb/scripts/axel.py
+++ b/.axel/hillclimb/scripts/axel.py
@@ -82,7 +82,8 @@ def write(path, content):
 
 
 def read(p):
-    return Path(p).read_text(encoding="utf-8")
+    path = Path(p)
+    return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
 def fingerprint_patch(repo_dir):

--- a/docs/prompts/prompts-hillclimb.md
+++ b/docs/prompts/prompts-hillclimb.md
@@ -6,6 +6,7 @@ slug: 'prompts-hillclimb'
 # Hillclimb Prompts
 
 Combined planner, coder and critique prompts used by Axel's hillclimb mode.
+The hillclimb CLI loads these prompts from `.axel/hillclimb/prompts/`.
 
 ## Plan Prompt
 

--- a/tests/test_hillclimb_script.py
+++ b/tests/test_hillclimb_script.py
@@ -1,0 +1,21 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "hillclimb_axel", Path(".axel/hillclimb/scripts/axel.py")
+)
+axel_script = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(axel_script)
+
+
+def test_read_missing_file_returns_empty(tmp_path):
+    missing = tmp_path / "missing.md"
+    assert axel_script.read(missing) == ""
+
+
+def test_create_task_markdown_no_prompts(tmp_path, monkeypatch):
+    monkeypatch.setattr(axel_script, "PROMPTS_DIR", tmp_path)
+    card = {"title": "Test", "key": "t", "acceptance_criteria": []}
+    cfg = {"touch_budget": {"files_max": 1, "loc_max": 1}}
+    result = axel_script.create_task_markdown("o/r", card, 1, cfg, tmp_path)
+    assert "AXEL TASK" in result


### PR DESCRIPTION
## Summary
- ensure hillclimb CLI tolerates absent prompt files
- add default planner/coder/critique prompts and document their location
- test hillclimb prompt loading
- format hillclimb test so pre-commit passes

## Testing
- `flake8 axel tests`
- `pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a3d6b00832fb984286b932f2678