### PR TITLE
📝 : relocate codex prompt docs

### DIFF
--- a/docs/prompts/codex/prompts-codex-ci-fix.md
+++ b/docs/prompts/codex/prompts-codex-ci-fix.md
@@ -25,7 +25,7 @@ CONTEXT:
   well-tested pull request that makes the workflow green again.
 - Constraints:
   * Do not break existing functionality.
-  * Follow AGENTS.md and README.md.
+  * Follow [AGENTS.md](../../AGENTS.md) and [README.md](../../README.md).
   * Run `flake8 axel tests`, `pytest --cov=axel --cov=tests`, and
     `pre-commit run --all-files` before proposing the PR.
   * Update tests and docs as needed.

--- a/docs/prompts/codex/prompts-codex-spellcheck.md
+++ b/docs/prompts/codex/prompts-codex-spellcheck.md
@@ -17,7 +17,7 @@ Keep Markdown documentation free of spelling errors.
 CONTEXT:
 - Check Markdown files using `codespell` (install with `uv pip install codespell` if missing).
 - Add unknown but legitimate words to `dict/allow.txt`.
-- Follow AGENTS.md and ensure `pre-commit run --all-files` passes.
+- Follow [AGENTS.md](../../AGENTS.md) and ensure `pre-commit run --all-files` passes.
 
 REQUEST:
 1. Run `codespell` over README and `docs/`.

--- a/docs/prompts/codex/prompts-codex.md
+++ b/docs/prompts/codex/prompts-codex.md
@@ -18,7 +18,7 @@ PURPOSE:
 Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
-- Follow the conventions in [AGENTS.md](../AGENTS.md) and [README.md](../README.md).
+- Follow the conventions in [AGENTS.md](../../AGENTS.md) and [README.md](../../README.md).
 - Scan for secrets:
 
   ```bash
@@ -123,7 +123,7 @@ Run `flake8 axel tests`, `pytest --cov=axel --cov=tests`, and
 `pre-commit run --all-files` before committing.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `prompts-codex.md`).
 2. Fix outdated instructions, links or formatting.
 3. Run the checks above.
 


### PR DESCRIPTION
what: move codex prompts into docs/prompts/codex and refresh links
why: satisfy flywheel prompt summary expectations
how to test: flake8 axel tests; pytest --cov=axel --cov=tests

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d76d3cf7b0832f8fd5f6f8d860b302