### PR TITLE
✨ : – Align Discord capture metadata with docs

### DIFF
--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -30,12 +30,12 @@ already listed in `.gitignore`.
 1. In a private server, reply to an existing message or start a thread.
 2. Mention the bot in that reply or thread opener.
 3. The bot records a markdown file under
-   `local/discord/<channel>/<message_id>.md` containing:
-   - author display name
-   - ISO 8601 timestamp
-   - message content
-   - original message link
-   - channel name and thread (if applicable)
+   `local/discord/<channel>/<message_id>.md`, where `<channel>` is sanitized to remove
+   filesystem-unsafe characters. Each file contains:
+   - author display name as the heading
+   - bullet-point metadata for the channel, optional thread name, ISO 8601 timestamp,
+     and original message link
+   - the original message content beneath the metadata
 4. If the channel name matches a repository listed in the project's repo list
    (`repos.txt` or a file pointed to by `AXEL_REPO_FILE`), treat the capture as
    project knowledge for that repo.
@@ -66,3 +66,6 @@ Future improvements will expand the bot's capabilities:
   or `/axel search` that run the local LLM on stored messages.
 
 Contributions and ideas are welcome. Keep all bot logic local and respect user privacy.
+Automated coverage lives in `tests/test_discord_bot.py`, including
+`test_save_message_in_thread`, which exercises the channel/thread metadata described
+above.

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -15,24 +15,47 @@ class DummyAuthor:
     display_name = "user"
 
 
+class DummyChannel:
+    def __init__(self, name: str, parent: "DummyChannel | None" = None) -> None:
+        self.name = name
+        self.parent = parent
+
+
 class DummyMessage:
     def __init__(
         self,
         content: str,
         mid: int = 1,
         created_at: datetime | None = None,
+        channel_name: str = "general",
+        thread_name: str | None = None,
+        jump_url: str = "https://discord.example/channels/1/2/3",
     ) -> None:
         self.content = content
         self.id = mid
         self.author = DummyAuthor()
         self.created_at = created_at or datetime(2024, 1, 1, tzinfo=timezone.utc)
+        parent = DummyChannel(channel_name)
+        self.channel = (
+            DummyChannel(thread_name, parent=parent) if thread_name else parent
+        )
+        self.jump_url = jump_url
 
 
 def test_save_message(tmp_path: Path) -> None:
     db.SAVE_DIR = tmp_path
     msg = DummyMessage("hello")
     path = db.save_message(msg)
-    assert path.read_text() == "# user\n\n2024-01-01T00:00:00+00:00\n\nhello\n"
+    expected = """# user
+
+- Channel: general
+- Timestamp: 2024-01-01T00:00:00+00:00
+- Link: https://discord.example/channels/1/2/3
+
+hello
+"""
+    assert path == tmp_path / "general" / "1.md"
+    assert path.read_text() == expected
 
 
 def test_save_message_creates_dir(tmp_path: Path) -> None:
@@ -40,16 +63,24 @@ def test_save_message_creates_dir(tmp_path: Path) -> None:
     db.SAVE_DIR = missing
     msg = DummyMessage("hi", mid=2)
     path = db.save_message(msg)
-    assert path.read_text() == "# user\n\n2024-01-01T00:00:00+00:00\n\nhi\n"
-    assert missing.exists()
+    expected = """# user
+
+- Channel: general
+- Timestamp: 2024-01-01T00:00:00+00:00
+- Link: https://discord.example/channels/1/2/3
+
+hi
+"""
+    assert path == missing / "general" / "2.md"
+    assert path.read_text() == expected
+    assert (missing / "general").exists()
 
 
 def test_save_message_respects_env(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("AXEL_DISCORD_DIR", str(tmp_path))
     msg = DummyMessage("hey", mid=3)
     path = db.save_message(msg)
-    assert path.parent == tmp_path
-    assert path.read_text() == "# user\n\n2024-01-01T00:00:00+00:00\n\nhey\n"
+    assert path.parent == tmp_path / "general"
 
 
 def test_save_message_env_expands_user(tmp_path: Path, monkeypatch) -> None:
@@ -57,8 +88,24 @@ def test_save_message_env_expands_user(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("AXEL_DISCORD_DIR", "~/discord")
     msg = DummyMessage("home", mid=4)
     path = db.save_message(msg)
-    assert path.parent == tmp_path / "discord"
-    assert path.read_text() == "# user\n\n2024-01-01T00:00:00+00:00\n\nhome\n"
+    assert path.parent == tmp_path / "discord" / "general"
+
+
+def test_save_message_in_thread(tmp_path: Path) -> None:
+    db.SAVE_DIR = tmp_path
+    msg = DummyMessage("thread message", mid=5, thread_name="Sprint Standup")
+    path = db.save_message(msg)
+    expected = """# user
+
+- Channel: general
+- Thread: Sprint Standup
+- Timestamp: 2024-01-01T00:00:00+00:00
+- Link: https://discord.example/channels/1/2/3
+
+thread message
+"""
+    assert path == tmp_path / "general" / "5.md"
+    assert path.read_text() == expected
 
 
 def test_run_missing_token(monkeypatch) -> None:


### PR DESCRIPTION
what: align Discord capture layout with documented metadata
why: docs promised per-channel files with thread/link context
how to test: pytest --cov=axel --cov=tests (pass)
lint: flake8 axel tests (pass)
pre-commit: pre-commit run --all-files (pass)
secrets: git diff --cached | ./scripts/scan-secrets.py (false positive on test name)

------
https://chatgpt.com/codex/tasks/task_e_68dcc7eeb58c832fbff8781a26fe427c