### PR TITLE
Add Discord thread context capture to saved messages

### DIFF
--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -38,6 +38,8 @@ tests.
    - bullet-point metadata for the channel, optional thread name, ISO 8601 timestamp,
      and original message link
    - the original message content beneath the metadata
+   - a **Context** section summarizing recent thread or channel history (oldest first) when
+     available, including author names, timestamps and links to the source messages
 4. If the channel name matches a repository listed in the project's repo list
    (`repos.txt` or a file pointed to by `AXEL_REPO_FILE`), treat the capture as
    project knowledge for that repo.
@@ -58,16 +60,14 @@ summarize discussions, extract tasks, or generate project insights.
 
 Automated coverage for the capture format lives in
 `tests/test_discord_bot.py::test_save_message_includes_metadata`,
-`tests/test_discord_bot.py::test_save_message_records_thread_metadata`, and
-`tests/test_discord_bot.py::test_capture_message_downloads_attachments`.
+`tests/test_discord_bot.py::test_save_message_records_thread_metadata`,
+`tests/test_discord_bot.py::test_capture_message_downloads_attachments`, and
+`tests/test_discord_bot.py::test_capture_message_includes_thread_history`.
 
 ## Roadmap
 
 Future improvements will expand the bot's capabilities:
 
-- **Thread history** – when mentioned inside a thread, call
-  `thread.history()` (or `channel.history()` for replies) to capture context
-  before saving.
 - **Command interface** – provide slash commands such as `/axel summarize`
   or `/axel search` that run the local LLM on stored messages.
 


### PR DESCRIPTION
## Summary
- capture recent Discord thread or channel history when persisting messages so saved markdown gains a Context section
- exercise the new behavior with coverage for threads, direct messages, and history edge cases
- document the Context section and reference the new regression tests in the Discord bot guide

## Testing
- flake8 axel tests
- pytest --cov=axel --cov=tests
- pre-commit run --all-files
- git diff --cached | ./scripts/scan-secrets.py *(false positives for DISCORD_BOT_TOKEN references)*

------
https://chatgpt.com/codex/tasks/task_e_68de058a4fc0832fb63464bc673d5aa7