### PR TITLE
✨ : – encrypt discord captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This launches the token.place server, relay and a mock LLM using one command.
 - [x] add `THREAT_MODEL.md` with cross-repo considerations (see `docs/THREAT_MODEL.md`)
 - [x] provide token rotation guidance in docs (see `docs/ROTATING_TOKENS.md`)
 - [x] adopt [`flywheel`](https://github.com/futuroptimist/flywheel) template for new repositories
-- [ ] encrypt notes saved under `local/discord/`
+- [x] encrypt notes saved under `local/discord/`
 - [x] review permissions for integrated tools (token.place, gabriel) (see docs/THREAT_MODEL.md)
 - [x] achieve 100% test coverage
 

--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -9,8 +9,12 @@ from pathlib import Path
 from typing import Sequence
 
 import discord
+from cryptography.fernet import Fernet
 
 SAVE_DIR = Path("local/discord")
+_KEY_ENV = "AXEL_DISCORD_KEY"
+_KEY_FILE_ENV = "AXEL_DISCORD_KEY_FILE"
+_DEFAULT_KEY_FILENAME = ".axel-discord.key"
 
 
 def _get_save_dir() -> Path:
@@ -29,6 +33,53 @@ def _sanitize_component(name: str | None) -> str:
     cleaned = (name or "unknown").strip()
     sanitized = _SAFE_COMPONENT.sub("_", cleaned)
     return sanitized or "unknown"
+
+
+def _fernet_from_raw(raw: str | bytes) -> Fernet:
+    """Return a Fernet instance constructed from ``raw`` key data."""
+
+    if isinstance(raw, str):
+        raw = raw.strip().encode()
+    try:
+        return Fernet(raw)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError(
+            "AXEL_DISCORD_KEY must be a valid base64-encoded 32-byte key"
+        ) from exc
+
+
+def _get_key_path(save_dir: Path) -> Path:
+    """Return the filesystem path for the Discord encryption key."""
+
+    override = os.getenv(_KEY_FILE_ENV)
+    if override:
+        return Path(override).expanduser()
+    return save_dir / _DEFAULT_KEY_FILENAME
+
+
+def _load_fernet(save_dir: Path, *, create: bool) -> Fernet:
+    """Return a Fernet instance for ``save_dir``.
+
+    When ``create`` is ``True`` and no key exists, a new key is generated and stored
+    alongside the captures. When ``False`` and no key exists, ``FileNotFoundError``
+    is raised.
+    """
+
+    env_key = os.getenv(_KEY_ENV)
+    if env_key:
+        return _fernet_from_raw(env_key)
+
+    key_path = _get_key_path(save_dir)
+    if key_path.exists():
+        return _fernet_from_raw(key_path.read_text(encoding="utf-8"))
+
+    if not create:
+        raise FileNotFoundError(key_path)
+
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key = Fernet.generate_key()
+    key_path.write_text(key.decode("utf-8"), encoding="utf-8")
+    return _fernet_from_raw(key)
 
 
 def _channel_metadata(message: discord.Message) -> tuple[str, str | None]:
@@ -50,20 +101,24 @@ def save_message(
     *,
     attachments: Sequence[tuple[str, Path]] | None = None,
 ) -> Path:
-    """Persist the provided message as markdown with metadata.
+    """Persist the provided message as encrypted markdown with metadata.
 
     Ensures the save directory exists before writing. The directory can be overridden
     via the ``AXEL_DISCORD_DIR`` environment variable. Messages are grouped by channel
-    name to match the documented layout ``local/discord/<channel>/<message_id>.md`` and
-    include channel/thread metadata, timestamps, the source link, and optional
-    attachment references when provided.
+    name to match the documented layout
+    ``local/discord/<channel>/<message_id>.md.enc`` and include channel/thread metadata,
+    timestamps, the source link, and optional attachment references when provided.
+    Content is encrypted using a Fernet key sourced from ``AXEL_DISCORD_KEY`` or
+    ``AXEL_DISCORD_KEY_FILE`` (defaulting to a generated key stored alongside the
+    captures).
     """
     save_dir = _get_save_dir()
+    fernet = _load_fernet(save_dir, create=True)
     channel_name, thread_name = _channel_metadata(message)
     channel_dir = save_dir / _sanitize_component(channel_name)
     channel_dir.mkdir(parents=True, exist_ok=True)
 
-    path = channel_dir / f"{message.id}.md"
+    path = channel_dir / f"{message.id}.md.enc"
     timestamp = message.created_at.isoformat()
     author = message.author.display_name
     jump_url = getattr(message, "jump_url", "")
@@ -87,7 +142,9 @@ def save_message(
             lines.append(f"- [{display_name}]({rel})")
         lines.append("")
 
-    path.write_text("\n".join(lines), encoding="utf-8")
+    content = "\n".join(lines)
+    encrypted = fernet.encrypt(content.encode("utf-8"))
+    path.write_bytes(encrypted)
     return path
 
 
@@ -127,6 +184,23 @@ async def capture_message(message: discord.Message) -> Path:
     channel_dir.mkdir(parents=True, exist_ok=True)
     attachments = await _download_attachments(message, channel_dir)
     return save_message(message, attachments=attachments)
+
+
+def decrypt_message(path: Path, *, key: str | bytes | None = None) -> str:
+    """Return decrypted markdown content for the saved Discord capture.
+
+    ``key`` may be provided explicitly; otherwise it is resolved from the same
+    environment variables and key file locations as :func:`save_message`.
+    """
+
+    save_dir = path.parent.parent
+    fernet = (
+        _fernet_from_raw(key)
+        if key is not None
+        else _load_fernet(save_dir, create=False)
+    )
+    decrypted = fernet.decrypt(path.read_bytes())
+    return decrypted.decode("utf-8")
 
 
 class AxelClient(discord.Client):

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -5,7 +5,8 @@ Axel coordinates multiple repositories and stores user notes locally. This docum
 - Secrets such as API keys should be stored in environment variables or encrypted files, never committed to source control.
 - The `local/` directory is ignored by Git by default. Verify this with `git check-ignore -v local/` after setup.
 - When using `token.place` or `gabriel`, review their permissions and rotate tokens regularly. See [docs/ROTATING_TOKENS.md](ROTATING_TOKENS.md) for detailed steps.
-- Notes saved under `local/discord/` stay on your machine. Future work may encrypt these files.
+- Notes saved under `local/discord/` stay on your machine and are encrypted with a Fernet key.
+  Store the key in `AXEL_DISCORD_KEY` or in a gitignored key file to avoid leaking it.
 - Before publishing the repository, scan for accidental secrets with:
 
   ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 authors = [{ name = "futuroptimist" }]
 license = { text = "MIT" }
 requires-python = ">=3.11"
-dependencies = ["requests==2.32.5"]
+dependencies = [
+    "requests==2.32.5",
+    "cryptography",
+]
 
 [project.scripts]
 axel-repo = "axel.repo_manager:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography
 pyyaml
 requests==2.32.5
 python-dotenv


### PR DESCRIPTION
what: encrypt Discord captures and add decrypt helper
why: ship promised encryption for local Discord notes
how to test: flake8 axel tests
how to test: pytest --cov=axel --cov=tests
how to test: pre-commit run --all-files
notes: git diff --cached | ./scripts/scan-secrets.py (docs/tests false positives)


------
https://chatgpt.com/codex/tasks/task_e_68de058a4fc0832fb63464bc673d5aa7