### PR TITLE
✨ : encrypt discord captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This launches the token.place server, relay and a mock LLM using one command.
 - [x] add `THREAT_MODEL.md` with cross-repo considerations (see `docs/THREAT_MODEL.md`)
 - [x] provide token rotation guidance in docs (see `docs/ROTATING_TOKENS.md`)
 - [x] adopt [`flywheel`](https://github.com/futuroptimist/flywheel) template for new repositories
-- [ ] encrypt notes saved under `local/discord/`
+- [x] encrypt notes saved under `local/discord/`
 - [x] review permissions for integrated tools (token.place, gabriel) (see docs/THREAT_MODEL.md)
 - [x] achieve 100% test coverage
 
@@ -81,6 +81,7 @@ pre-commit install
 11. Clear all tasks with `python -m axel.task_manager clear`.
 12. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
 13. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
+14. Set `AXEL_DISCORD_ENCRYPTION_KEY` to a Fernet key to encrypt Discord captures on disk.
 
 ## local setup
 

--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Sequence
 
 import discord
+from cryptography.fernet import Fernet
 
 SAVE_DIR = Path("local/discord")
 CONTEXT_LIMIT = 5
@@ -31,6 +32,20 @@ def _sanitize_component(name: str | None) -> str:
     cleaned = (name or "unknown").strip()
     sanitized = _SAFE_COMPONENT.sub("_", cleaned)
     return sanitized or "unknown"
+
+
+def _get_encrypter() -> Fernet | None:
+    """Return a Fernet instance when encryption is enabled."""
+
+    key = os.getenv("AXEL_DISCORD_ENCRYPTION_KEY", "").strip()
+    if not key:
+        return None
+    try:
+        return Fernet(key.encode())
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise RuntimeError(
+            "AXEL_DISCORD_ENCRYPTION_KEY must be a valid Fernet key"
+        ) from exc
 
 
 def _channel_metadata(message: discord.Message) -> tuple[str, str | None]:
@@ -137,7 +152,13 @@ def save_message(
             lines.append(f"- [{display_name}]({rel})")
         lines.append("")
 
-    path.write_text("\n".join(lines), encoding="utf-8")
+    rendered = "\n".join(lines)
+    encrypter = _get_encrypter()
+    if encrypter:
+        token = encrypter.encrypt(rendered.encode("utf-8"))
+        path.write_bytes(token)
+    else:
+        path.write_text(rendered, encoding="utf-8")
     return path
 
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -5,7 +5,8 @@ Axel coordinates multiple repositories and stores user notes locally. This docum
 - Secrets such as API keys should be stored in environment variables or encrypted files, never committed to source control.
 - The `local/` directory is ignored by Git by default. Verify this with `git check-ignore -v local/` after setup.
 - When using `token.place` or `gabriel`, review their permissions and rotate tokens regularly. See [docs/ROTATING_TOKENS.md](ROTATING_TOKENS.md) for detailed steps.
-- Notes saved under `local/discord/` stay on your machine. Future work may encrypt these files.
+- Notes saved under `local/discord/` stay on your machine. Set `AXEL_DISCORD_ENCRYPTION_KEY`
+  with a Fernet key to encrypt captures at rest.
 - Before publishing the repository, scan for accidental secrets with:
 
   ```bash

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -27,6 +27,21 @@ already listed in `.gitignore`. The helper `axel.discord_bot.capture_message` do
 attachments before writing the markdown file, making it easy to exercise the behavior in
 tests.
 
+## Encrypting Captures
+
+Set `AXEL_DISCORD_ENCRYPTION_KEY` to a
+[Fernet](https://cryptography.io/en/latest/fernet/) key to encrypt saved markdown files.
+When the variable is set, `save_message` writes an encrypted token instead of plaintext
+markdown. Generate a key locally with:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+Store the key securely (for example, in a password manager) and export it before running
+the bot. Attachments remain on disk in plaintext so they can be referenced by the markdown
+once decrypted.
+
 ## Workflow
 
 1. In a private server, reply to an existing message or start a thread.
@@ -64,8 +79,9 @@ Automated coverage for the capture format lives in
 `tests/test_discord_bot.py::test_save_message_includes_metadata`,
 `tests/test_discord_bot.py::test_save_message_records_thread_metadata`,
 `tests/test_discord_bot.py::test_save_message_includes_context`,
-`tests/test_discord_bot.py::test_gather_context_reads_channel_history`, and
-`tests/test_discord_bot.py::test_capture_message_downloads_attachments`.
+`tests/test_discord_bot.py::test_gather_context_reads_channel_history`,
+`tests/test_discord_bot.py::test_capture_message_downloads_attachments`, and
+`tests/test_discord_bot.py::test_save_message_encrypts_when_key_set`.
 
 ## Roadmap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 authors = [{ name = "futuroptimist" }]
 license = { text = "MIT" }
 requires-python = ">=3.11"
-dependencies = ["requests==2.32.5"]
+dependencies = [
+    "cryptography==42.0.8",
+    "requests==2.32.5",
+]
 
 [project.scripts]
 axel-repo = "axel.repo_manager:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pyyaml
+cryptography==42.0.8
 requests==2.32.5
 python-dotenv
 rich

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from cryptography.fernet import Fernet
 
 discord = pytest.importorskip("discord")
 
@@ -127,6 +128,24 @@ def test_save_message_env_expands_user(tmp_path: Path, monkeypatch) -> None:
     path = db.save_message(msg)
     assert path == tmp_path / "discord" / "general" / "4.md"
     assert "home" in read_markdown(path)
+
+
+def test_save_message_encrypts_when_key_set(tmp_path: Path, monkeypatch) -> None:
+    """When an encryption key is configured the saved file is encrypted."""
+
+    key = Fernet.generate_key()
+    db.SAVE_DIR = Path("local/discord")
+    monkeypatch.setenv("AXEL_DISCORD_DIR", str(tmp_path))
+    monkeypatch.setenv("AXEL_DISCORD_ENCRYPTION_KEY", key.decode())
+    msg = DummyMessage("secret payload", mid=99, channel=DummyChannel("general"))
+
+    path = db.save_message(msg)
+
+    assert path == tmp_path / "general" / "99.md"
+    raw = path.read_bytes()
+    assert b"secret payload" not in raw
+    decrypted = Fernet(key).decrypt(raw).decode()
+    assert "secret payload" in decrypted
 
 
 def test_save_message_records_thread_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
what: add Fernet-based encryption for Discord saves and docs/tests
why: fulfill threat model promise to protect local captures
how to test: flake8 axel tests
  pytest --cov=axel --cov=tests
  pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68dec056232c832f9e2ef6885478e796