### PR TITLE
✨ : – capture thread mentions in Discord bot

### DIFF
--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -302,16 +302,31 @@ class AxelClient(discord.Client):
     async def on_message(self, message: discord.Message) -> None:  # pragma: no cover
         if self.user is None or message.author == self.user:
             return
-        if self.user.mentioned_in(message) and message.reference:
-            original = await message.channel.fetch_message(message.reference.message_id)
-            context = await _gather_context(message)
-            context = [
-                ctx
-                for ctx in context
-                if getattr(ctx, "id", None) != getattr(original, "id", None)
-            ]
-            path = await capture_message(original, context=context)
-            await message.channel.send(f"Saved to {path}")
+        if not self.user.mentioned_in(message):
+            return
+
+        context = await _gather_context(message)
+
+        original: discord.Message | None = None
+        reference = getattr(message, "reference", None)
+        message_id = getattr(reference, "message_id", None)
+
+        if message_id is not None and hasattr(message.channel, "fetch_message"):
+            try:
+                original = await message.channel.fetch_message(message_id)
+            except Exception:
+                original = None
+
+        if original is None:
+            original = message
+
+        filtered_context = [
+            ctx
+            for ctx in context
+            if getattr(ctx, "id", None) != getattr(original, "id", None)
+        ]
+        path = await capture_message(original, context=filtered_context)
+        await message.channel.send(f"Saved to {path}")
 
 
 def run() -> None:

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -30,7 +30,8 @@ tests.
 ## Workflow
 
 1. In a private server, reply to an existing message or start a thread.
-2. Mention the bot in that reply or thread opener.
+2. Mention the bot in that reply or thread opener. Mentions inside thread openers are
+   captured even when Discord omits a ``message.reference`` pointer.
 3. The bot records a markdown file under
    `local/discord/<channel>/<message_id>.md`, where `<channel>` is sanitized to remove
    filesystem-unsafe characters. Each file contains:
@@ -64,8 +65,9 @@ Automated coverage for the capture format lives in
 `tests/test_discord_bot.py::test_save_message_includes_metadata`,
 `tests/test_discord_bot.py::test_save_message_records_thread_metadata`,
 `tests/test_discord_bot.py::test_save_message_includes_context`,
-`tests/test_discord_bot.py::test_gather_context_reads_channel_history`, and
-`tests/test_discord_bot.py::test_capture_message_downloads_attachments`.
+`tests/test_discord_bot.py::test_gather_context_reads_channel_history`,
+`tests/test_discord_bot.py::test_capture_message_downloads_attachments`, and
+`tests/test_discord_bot.py::test_axel_client_captures_thread_mentions`.
 
 ## Roadmap
 


### PR DESCRIPTION
what: allow AxelClient to persist thread mentions lacking message.reference, document the behavior, and cover it with tests
why: docs promised thread openers would be ingested but the bot ignored them
how to test: flake8 axel tests; pytest --cov=axel --cov=tests; pre-commit run --all-files; git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dec056232c832f9e2ef6885478e796