### PR TITLE
Expand tilde handling for repo and task file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ pre-commit install
 To keep personal notes and repo lists private, set `AXEL_REPO_FILE` to a path
 under `local/`, which is ignored by Git. The repo manager creates the directory
 automatically if it doesn't already exist. Paths beginning with `~` expand to
-the user's home directory.
+the user's home directory. Automated coverage for this behavior lives in
+`tests/test_repo_manager.py::test_add_repo_expands_user_home` and
+`tests/test_task_manager.py::test_add_task_expands_user_home`.
 
 Example:
 

--- a/axel/repo_manager.py
+++ b/axel/repo_manager.py
@@ -16,6 +16,14 @@ def get_repo_file() -> Path:
     return Path(os.getenv("AXEL_REPO_FILE", DEFAULT_REPO_FILE)).expanduser()
 
 
+def _resolve_path(path: Path | None) -> Path:
+    """Return ``path`` with ``~`` expanded, defaulting to :func:`get_repo_file`."""
+
+    if path is None:
+        return get_repo_file()
+    return Path(path).expanduser()
+
+
 def load_repos(path: Path | None = None) -> List[str]:
     """Load repository URLs from a text file.
 
@@ -23,8 +31,7 @@ def load_repos(path: Path | None = None) -> List[str]:
     removed case-insensitively while preserving the first occurrence's case.
     The resulting list is sorted alphabetically, ignoring case.
     """
-    if path is None:
-        path = get_repo_file()
+    path = _resolve_path(path)
     if not path.exists():
         return []
     repos: List[str] = []
@@ -48,8 +55,7 @@ def add_repo(url: str, path: Path | None = None) -> List[str]:
     in ``url`` are removed before processing. Comparison is case-insensitive. The
     resulting list is kept sorted alphabetically regardless of case.
     """
-    if path is None:
-        path = get_repo_file()
+    path = _resolve_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     url = url.strip().rstrip("/")
     if "://" not in url:
@@ -72,8 +78,7 @@ def remove_repo(url: str, path: Path | None = None) -> List[str]:
     case-insensitive. The remaining list is kept sorted alphabetically,
     ignoring case.
     """
-    if path is None:
-        path = get_repo_file()
+    path = _resolve_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     url = url.strip().rstrip("/")
     repos = load_repos(path)
@@ -144,8 +149,7 @@ def fetch_repos(
     ``token`` overrides ``GH_TOKEN``/``GITHUB_TOKEN`` when provided.
     ``visibility`` filters repositories returned by the GitHub API.
     """
-    if path is None:
-        path = get_repo_file()
+    path = _resolve_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     repos = fetch_repo_urls(token=token, visibility=visibility)
     text = "\n".join(repos)

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -12,13 +12,20 @@ def get_task_file() -> Path:
     return Path(os.getenv("AXEL_TASK_FILE", DEFAULT_TASK_FILE)).expanduser()
 
 
+def _resolve_path(path: Path | None) -> Path:
+    """Return ``path`` with ``~`` expanded, defaulting to :func:`get_task_file`."""
+
+    if path is None:
+        return get_task_file()
+    return Path(path).expanduser()
+
+
 def load_tasks(path: Path | None = None) -> List[Dict]:
     """Load tasks from a JSON file.
 
     Returns an empty list for missing, empty, invalid, or non-list JSON files.
     """
-    if path is None:
-        path = get_task_file()
+    path = _resolve_path(path)
     if not path.exists():
         return []
     try:
@@ -37,8 +44,7 @@ def add_task(description: str, path: Path | None = None) -> List[Dict]:
 
     ``description`` is stripped of surrounding whitespace and must not be empty.
     """
-    if path is None:
-        path = get_task_file()
+    path = _resolve_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     description = description.strip()
     if not description:
@@ -56,8 +62,7 @@ def add_task(description: str, path: Path | None = None) -> List[Dict]:
 
 def complete_task(task_id: int, path: Path | None = None) -> List[Dict]:
     """Mark the task with ``task_id`` as completed."""
-    if path is None:
-        path = get_task_file()
+    path = _resolve_path(path)
     tasks = load_tasks(path)
     for task in tasks:
         if task["id"] == task_id:
@@ -72,8 +77,7 @@ def complete_task(task_id: int, path: Path | None = None) -> List[Dict]:
 
 def remove_task(task_id: int, path: Path | None = None) -> List[Dict]:
     """Remove the task with ``task_id`` from the JSON database."""
-    if path is None:
-        path = get_task_file()
+    path = _resolve_path(path)
     tasks = load_tasks(path)
     new_tasks = [t for t in tasks if t["id"] != task_id]
     if len(new_tasks) == len(tasks):
@@ -92,8 +96,7 @@ def list_tasks(path: Path | None = None) -> List[Dict]:
 
 def clear_tasks(path: Path | None = None) -> List[Dict]:
     """Remove all tasks from the JSON database."""
-    if path is None:
-        path = get_task_file()
+    path = _resolve_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("[]\n", encoding="utf-8")
     return []

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -100,6 +100,15 @@ def test_load_repos_sorts_entries(tmp_path: Path) -> None:
     ]
 
 
+def test_add_repo_expands_user_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    file = Path("~/repos.txt")
+    add_repo("https://example.com/repo", path=file)
+    expected = tmp_path / "repos.txt"
+    assert expected.exists()
+    assert load_repos(path=file) == ["https://example.com/repo"]
+
+
 def test_add_repo_no_duplicates(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -75,6 +75,18 @@ def test_remove_task_missing_id(tmp_path: Path) -> None:
         remove_task(2, path=file)
 
 
+def test_add_task_expands_user_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = Path("~/tasks.json")
+    add_task("home scoped", path=target)
+    expected = tmp_path / "tasks.json"
+    assert expected.exists()
+    tasks = load_tasks(path=target)
+    assert tasks == [
+        {"id": 1, "description": "home scoped", "completed": False},
+    ]
+
+
 def test_cli_add(tmp_path: Path) -> None:
     file = tmp_path / "tasks.json"
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- ensure repo_manager and task_manager expand ~ for explicit --path arguments
- add regression tests covering tilde expansion and document coverage in README

## Testing
- python -m flake8 axel tests
- pytest --cov=axel --cov=tests
- python -m pre_commit run --all-files
- GIT_DIFF_OPTS=--unified=0 git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dec056232c832f9e2ef6885478e796