### PR TITLE
Ensure Discord captures emit a single context section

### DIFF
--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -97,25 +97,6 @@ def save_message(
                 continue
             author = _display_name(getattr(ctx, "author", None))
             timestamp = getattr(ctx, "created_at", None)
-            ts_str = timestamp.isoformat() if hasattr(timestamp, "isoformat") else ""
-            body = getattr(ctx, "content", "") or "(no content)"
-            entry = f"- {author}: {body}"
-            if ts_str:
-                entry += f" ({ts_str})"
-            context_lines.append(entry)
-    if context_lines:
-        lines.append("## Context")
-        lines.extend(context_lines)
-        lines.append("")
-
-    lines.append(message.content)
-    lines.append("")
-
-    if context:
-        lines.append("## Context")
-        for ctx in context:
-            author = getattr(getattr(ctx, "author", None), "display_name", "unknown")
-            timestamp = getattr(ctx, "created_at", None)
             ts = timestamp.isoformat() if isinstance(timestamp, datetime) else ""
             jump_url = getattr(ctx, "jump_url", "")
             entry = f"- {author}"
@@ -123,11 +104,19 @@ def save_message(
                 entry += f" @ {ts}"
             if jump_url:
                 entry += f" ({jump_url})"
-            lines.append(entry)
-            content = getattr(ctx, "content", "")
-            if content:
-                lines.append(f"  {content}")
+            context_lines.append(entry)
+            body = getattr(ctx, "content", "")
+            if body:
+                context_lines.append(f"  {body}")
+            else:
+                context_lines.append("  (no content)")
+    if context_lines:
+        lines.append("## Context")
+        lines.extend(context_lines)
         lines.append("")
+
+    lines.append(message.content)
+    lines.append("")
     if attachments:
         lines.append("## Attachments")
         for display_name, relative_path in attachments:

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -37,11 +37,10 @@ tests.
    - author display name as the heading
    - bullet-point metadata for the channel, optional thread name, ISO 8601 timestamp,
      and original message link
-   - a `## Context` section containing the latest thread or reply history (up to five
-     messages) when the bot is mentioned inside a conversation
-   - the original message content beneath the metadata
-   - a **Context** section summarizing recent thread or channel history (oldest first) when
-     available, including author names, timestamps and links to the source messages
+   - a `## Context` section (when available) listing up to five prior messages in
+     oldest-first order. Each entry records the author, timestamp, source link, and an
+     indented line with the original message text (or `(no content)` when empty).
+   - the captured message content beneath the metadata and context
 4. If the channel name matches a repository listed in the project's repo list
    (`repos.txt` or a file pointed to by `AXEL_REPO_FILE`), treat the capture as
    project knowledge for that repo.
@@ -64,6 +63,7 @@ Automated coverage for the capture format lives in
 `tests/test_discord_bot.py::test_save_message_includes_metadata`,
 `tests/test_discord_bot.py::test_save_message_records_thread_metadata`,
 `tests/test_discord_bot.py::test_save_message_includes_context`,
+`tests/test_discord_bot.py::test_save_message_writes_single_context_section`,
 `tests/test_discord_bot.py::test_gather_context_reads_channel_history`, and
 `tests/test_discord_bot.py::test_capture_message_downloads_attachments`.
 

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -65,6 +65,34 @@ def test_save_message_includes_context(tmp_path: Path) -> None:
     assert "mention" in content
 
 
+def test_save_message_writes_single_context_section(tmp_path: Path) -> None:
+    """Context history is emitted once with metadata for each message."""
+
+    db.SAVE_DIR = tmp_path
+    context = [
+        DummyMessage(
+            "earlier",
+            mid=20,
+            created_at=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+        ),
+        DummyMessage(
+            "mention",
+            mid=21,
+            created_at=datetime(2024, 1, 1, 0, 5, tzinfo=timezone.utc),
+        ),
+    ]
+    msg = DummyMessage("final", mid=22, channel=DummyChannel("general"))
+
+    path = db.save_message(msg, context=context)
+
+    content = read_markdown(path)
+    assert content.count("## Context") == 1
+    assert "earlier" in content
+    assert "mention" in content
+    context_section = content.split("## Context", 1)[1]
+    assert context_section.count("- user @") == 2
+
+
 def test_save_message_context_skips_self(tmp_path: Path) -> None:
     """Context entries skip the saved message and handle missing author data."""
 


### PR DESCRIPTION
## Summary
- collapse discord message saving so context history is written once with metadata and message text
- add a regression test covering the single Context block formatting
- update docs/discord-bot.md to describe the merged Context layout and list the new test

## Testing
- pytest --cov=axel --cov=tests
- flake8 axel tests
- pre-commit run --all-files
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dec056232c832f9e2ef6885478e796