### PR TITLE
Add repository metadata to Discord captures

### DIFF
--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -51,15 +51,17 @@ once decrypted.
    `local/discord/<channel>/<message_id>.md`, where `<channel>` is sanitized to remove
    filesystem-unsafe characters. Each file contains:
    - author display name as the heading
-   - bullet-point metadata for the channel, optional thread name, ISO 8601 timestamp,
+   - bullet-point metadata for the channel, optional thread name, matching repository
+     URLs when the channel corresponds to an entry in the repo list, ISO 8601 timestamp,
      and original message link
    - a `## Context` section (when available) listing up to five prior messages in
      oldest-first order. Each entry records the author, timestamp, source link, and an
      indented line with the original message text (or `(no content)` when empty).
    - the captured message content beneath the metadata and context
 4. If the channel name matches a repository listed in the project's repo list
-   (`repos.txt` or a file pointed to by `AXEL_REPO_FILE`), treat the capture as
-   project knowledge for that repo.
+   (`repos.txt` or a file pointed to by `AXEL_REPO_FILE`), the saved metadata
+   includes a `Repository:` entry pointing to the matching URL so you can treat the
+   capture as project knowledge for that repo.
 
 ### Supported Content Types
 
@@ -77,6 +79,7 @@ summarize discussions, extract tasks, or generate project insights.
 
 Automated coverage for the capture format lives in
 `tests/test_discord_bot.py::test_save_message_includes_metadata`,
+`tests/test_discord_bot.py::test_save_message_includes_repository_metadata`,
 `tests/test_discord_bot.py::test_save_message_records_thread_metadata`,
 `tests/test_discord_bot.py::test_save_message_includes_context`,
 `tests/test_discord_bot.py::test_gather_context_reads_channel_history`,


### PR DESCRIPTION
## Summary
- annotate saved Discord markdown with matching repository URLs when the channel name maps to an entry in repos.txt
- extend the Discord bot tests to cover repository metadata, blank channel names, and empty repo list entries
- document the new metadata in docs/discord-bot.md and reference the added test case

## Testing
- flake8 axel tests
- pytest --cov=axel --cov=tests --cov-report term-missing
- pre-commit run --all-files
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68df7d82b774832f94f2d1deea348182