### PR TITLE
Add gabriel guidance to token quests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ pairings that highlight how multiple repositories can collaborate on a shared go
 module powers the "suggest quests" promise described in the roadmap and is covered by
 `tests/test_quests.py::test_suggest_cross_repo_quests_links_repos` and
 `tests/test_quests.py::test_cli_prints_suggestions`.
+Quests that involve token.place automatically reference `gabriel` to reinforce the
+security layer described in `issues/0003-gabriel-security-layer.md`; see
+`tests/test_quests.py::test_suggest_cross_repo_quests_mentions_gabriel_for_sensitive_pairs`.
 11. Clear all tasks with `python -m axel.task_manager clear`.
 12. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
 13. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
@@ -100,6 +103,9 @@ pairings that highlight how multiple repositories can collaborate on a shared go
 module powers the "suggest quests" promise described in the roadmap and is covered by
 `tests/test_quests.py::test_suggest_cross_repo_quests_links_repos` and
 `tests/test_quests.py::test_cli_prints_suggestions`.
+Quests that involve token.place automatically reference `gabriel` to reinforce the
+security layer described in `issues/0003-gabriel-security-layer.md`; see
+`tests/test_quests.py::test_suggest_cross_repo_quests_mentions_gabriel_for_sensitive_pairs`.
 
 ## local setup
 

--- a/axel/quests.py
+++ b/axel/quests.py
@@ -47,8 +47,8 @@ _KEYWORD_TEMPLATES: tuple[KeywordTemplate, ...] = (
     (
         "token",
         (
-            "{primary} can broker token.place authentication to streamline onboarding "
-            "for {secondary}."
+            "{primary} can broker token.place auth while gabriel audits secrets "
+            "so {secondary} ships safely."
         ),
     ),
     (

--- a/issues/0003-gabriel-security-layer.md
+++ b/issues/0003-gabriel-security-layer.md
@@ -3,5 +3,6 @@
 `gabriel` acts as a security layer across projects by providing OSINT tools that help protect personal safety. Document how gabriel can be integrated with other repos listed in `repos.txt`.
 
 - [x] add examples of using gabriel alongside `token.place` and `dspace`
-- [ ] mention gabriel in future quests that involve sensitive data
+- [x] mention gabriel in future quests that involve sensitive data (see
+  `tests/test_quests.py::test_suggest_cross_repo_quests_mentions_gabriel_for_sensitive_pairs`)
 - [ ] keep README entries updated as integration progresses

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -26,6 +26,19 @@ def test_suggest_cross_repo_quests_links_repos() -> None:
     assert "security" in first["details"].lower()
 
 
+def test_suggest_cross_repo_quests_mentions_gabriel_for_sensitive_pairs() -> None:
+    from axel.quests import suggest_cross_repo_quests
+
+    repos = [
+        "https://github.com/futuroptimist/token.place",
+        "https://github.com/futuroptimist/dspace",
+    ]
+
+    suggestions = suggest_cross_repo_quests(repos, limit=1)
+
+    assert "gabriel" in suggestions[0]["details"].lower()
+
+
 @pytest.mark.parametrize(
     "repos",
     [


### PR DESCRIPTION
## Summary
- ensure token.place quest templates mention gabriel for sensitive collaborations
- add regression coverage that asserts gabriel is suggested alongside token.place
- document the behavior in the README and mark the roadmap issue item as complete

## Testing
- flake8 axel tests
- pytest --cov=axel --cov=tests
- pre-commit run --all-files
- git diff --cached | ./scripts/scan-secrets.py *(flags "token" references; no secrets committed)*

Refs: issues/0003-gabriel-security-layer.md

------
https://chatgpt.com/codex/tasks/task_e_68e1b67f84f4832f9df1eea09af3c1a5