### PR TITLE
✨ : – Enforce Discord context limit

### DIFF
--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -163,6 +163,8 @@ def save_message(
             entries.sort(key=_context_sort_key)
         except Exception:
             pass
+        if CONTEXT_LIMIT is not None and len(entries) > CONTEXT_LIMIT:
+            entries = entries[-CONTEXT_LIMIT:]
         for ctx in entries:
             author = _display_name(getattr(ctx, "author", None))
             timestamp = getattr(ctx, "created_at", None)

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -84,6 +84,7 @@ Automated coverage for the capture format lives in
 `tests/test_discord_bot.py::test_save_message_records_thread_metadata`,
 `tests/test_discord_bot.py::test_save_message_includes_context`,
 `tests/test_discord_bot.py::test_save_message_orders_context_oldest_first`,
+`tests/test_discord_bot.py::test_save_message_limits_context_entries`,
 `tests/test_discord_bot.py::test_gather_context_reads_channel_history`,
 `tests/test_discord_bot.py::test_capture_message_downloads_attachments`, and
 `tests/test_discord_bot.py::test_save_message_encrypts_when_key_set`.


### PR DESCRIPTION
what: cap Discord captures at five prior messages and note coverage
why: docs promise the limit but save_message accepted unlimited context
how to test: pytest --cov=axel --cov=tests
extra: flake8 axel tests
extra: pre-commit run --all-files
extra: git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e35347b7c8832f8d3cc56974ee81b6