### PR TITLE
🛠️ : – allow --path after subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ pre-commit install
    ``GITHUB_TOKEN``. Use `--visibility public|private|all` to filter the
    repositories returned by the GitHub API.
 5. Run `pre-commit run --all-files` before committing to check formatting and tests.
-6. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list.
+6. Pass `--path <file>` or set `AXEL_REPO_FILE` to use a custom repo list. The CLI accepts
+   `--path` before or after the subcommand (see
+   `tests/test_repo_manager.py::test_main_add_accepts_path_after_subcommand`).
 7. Coverage reports are uploaded to [Codecov](https://codecov.io/gh/futuroptimist/axel) via CI.
 8. Add a task with `python -m axel.task_manager add "write docs"`. Tasks are
    saved in `tasks.json` and listed with `python -m axel.task_manager list`.
@@ -91,7 +93,9 @@ Quests that involve token.place automatically reference `gabriel` to reinforce t
 security layer described in `issues/0003-gabriel-security-layer.md`; see
 `tests/test_quests.py::test_suggest_cross_repo_quests_mentions_gabriel_for_sensitive_pairs`.
 11. Clear all tasks with `python -m axel.task_manager clear`.
-12. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list.
+12. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list. The task CLI also
+    accepts `--path` before or after the subcommand (see
+    `tests/test_task_manager.py::test_main_add_accepts_path_after_subcommand`).
 13. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
 14. Set `AXEL_DISCORD_ENCRYPTION_KEY` to a Fernet key to encrypt Discord captures on disk.
 

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -36,6 +36,26 @@ def test_cli_list_with_path(tmp_path: Path):
     assert "https://example.com/repo" in result.stdout
 
 
+def test_main_add_accepts_path_after_subcommand(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from axel.repo_manager import main
+
+    file = tmp_path / "repos.txt"
+
+    main(
+        [
+            "add",
+            "https://example.com/repo",
+            "--path",
+            str(file),
+        ]
+    )
+
+    assert load_repos(path=file) == ["https://example.com/repo"]
+    assert "https://example.com/repo" in capsys.readouterr().out
+
+
 def test_cli_remove(tmp_path: Path):
     file = tmp_path / "repos.txt"
     add_repo("https://example.com/repo", path=file)

--- a/tests/test_repo_manager.py
+++ b/tests/test_repo_manager.py
@@ -119,8 +119,9 @@ def test_main_add_accepts_path_before_subcommand(
 def test_main_uses_sys_argv_when_none(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from axel import repo_manager
     import types
+
+    from axel import repo_manager
 
     file = tmp_path / "repos.txt"
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -134,6 +134,110 @@ def test_main_add_accepts_path_after_subcommand(
     assert "1 [ ] write docs" in capsys.readouterr().out
 
 
+def test_main_add_uses_default_task_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from axel import task_manager
+
+    default_file = tmp_path / "tasks.json"
+    monkeypatch.setattr(task_manager, "get_task_file", lambda: default_file)
+
+    task_manager.main(["add", "write docs"])
+
+    assert load_tasks(path=default_file) == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+
+
+def test_main_add_supports_path_equals_form(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from axel import task_manager
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    target = Path("~") / "nested" / "tasks.json"
+
+    task_manager.main(
+        [
+            "add",
+            "write docs",
+            f"--path={target}",
+        ]
+    )
+
+    expected_file = home / "nested" / "tasks.json"
+    assert load_tasks(path=expected_file) == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+
+
+def test_main_add_accepts_path_before_subcommand(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from axel import task_manager
+
+    class SneakyStr(str):
+        def __eq__(self, other: object) -> bool:
+            return False
+
+        __hash__ = str.__hash__
+
+    file = tmp_path / "tasks.json"
+    argv = [
+        SneakyStr("--path"),
+        str(file),
+        "add",
+        "write docs",
+    ]
+
+    task_manager.main(argv)
+
+    assert load_tasks(path=file) == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+
+
+def test_main_uses_sys_argv_when_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from axel import task_manager
+    import types
+
+    file = tmp_path / "tasks.json"
+
+    monkeypatch.setattr(
+        task_manager,
+        "sys",
+        types.SimpleNamespace(
+            argv=[
+                "prog",
+                "add",
+                "write docs",
+                "--path",
+                str(file),
+            ]
+        ),
+    )
+
+    task_manager.main(None)
+
+    assert load_tasks(path=file) == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+
+
+def test_main_rejects_path_without_value() -> None:
+    from axel.task_manager import main
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["add", "write docs", "--path"])
+
+    assert excinfo.value.code != 0
+
+
 def test_cli_complete(tmp_path: Path) -> None:
     file = tmp_path / "tasks.json"
     add_task("write docs", path=file)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -203,8 +203,9 @@ def test_main_add_accepts_path_before_subcommand(
 def test_main_uses_sys_argv_when_none(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from axel import task_manager
     import types
+
+    from axel import task_manager
 
     file = tmp_path / "tasks.json"
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -112,6 +112,28 @@ def test_cli_add(tmp_path: Path) -> None:
     assert "1 [ ] write code" in result.stdout
 
 
+def test_main_add_accepts_path_after_subcommand(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from axel.task_manager import main
+
+    file = tmp_path / "tasks.json"
+
+    main(
+        [
+            "add",
+            "write docs",
+            "--path",
+            str(file),
+        ]
+    )
+
+    assert load_tasks(path=file) == [
+        {"id": 1, "description": "write docs", "completed": False},
+    ]
+    assert "1 [ ] write docs" in capsys.readouterr().out
+
+
 def test_cli_complete(tmp_path: Path) -> None:
     file = tmp_path / "tasks.json"
     add_task("write docs", path=file)


### PR DESCRIPTION
what: align repo/task CLIs with documented --path usage and add tests/docs
why: README promised `python -m ... add ... --path ...` but CLI rejected it
how to test: flake8 axel tests; pytest --cov=axel --cov=tests;
  pre-commit run --all-files

commands:
- ✅ flake8 axel tests
- ✅ pytest --cov=axel --cov=tests
- ✅ pre-commit run --all-files
- ⚠️ git diff --cached | ./scripts/scan-secrets.py (README tokens flagged)

Refs: #readme

------
https://chatgpt.com/codex/tasks/task_e_68e35347b7c8832f8d3cc56974ee81b6