### PR TITLE
✨ : – Add flywheel workflow audit CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ security layer described in `issues/0003-gabriel-security-layer.md`; see
     `tests/test_task_manager.py::test_main_add_accepts_path_after_subcommand`).
 13. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
 14. Set `AXEL_DISCORD_ENCRYPTION_KEY` to a Fernet key to encrypt Discord captures on disk.
+15. Audit repositories for flywheel workflow coverage with `python -m axel.flywheel --path repos.txt`.
+    The command reports missing workflows (lint/tests) so you can align each project with the
+    flywheel template. Automated coverage lives in
+    `tests/test_flywheel.py::test_evaluate_flywheel_alignment_reports_missing_workflows` and
+    `tests/test_flywheel.py::test_main_prints_alignment_summary`.
 
 ## quests
 

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -1,5 +1,6 @@
 """axel package."""
 
+from .flywheel import evaluate_flywheel_alignment
 from .quests import suggest_cross_repo_quests
 from .repo_manager import add_repo, get_repo_file, list_repos, load_repos, remove_repo
 from .task_manager import (
@@ -31,6 +32,7 @@ __all__ = [
     "run_discord_bot",
     "strip_ansi",
     "suggest_cross_repo_quests",
+    "evaluate_flywheel_alignment",
     "add_task",
     "complete_task",
     "get_task_file",

--- a/axel/flywheel.py
+++ b/axel/flywheel.py
@@ -21,15 +21,23 @@ _API_TIMEOUT = 10
 def _slug_from_url(url: str) -> str:
     """Return ``owner/repo`` slug for ``url`` or raise ``ValueError``."""
 
+    def _clean_repo(segment: str) -> str:
+        """Return the repository portion of ``segment`` without a ``.git`` suffix."""
+
+        repo = segment.split("/", 1)[0]
+        return repo[:-4] if repo.endswith(".git") else repo
+
     parsed = urlparse(url)
     if parsed.netloc:
         parts = [part for part in parsed.path.split("/") if part]
         if len(parts) >= 2:
-            return f"{parts[0]}/{parts[1]}"
+            owner = parts[0]
+            repo = _clean_repo(parts[1])
+            return f"{owner}/{repo}"
     cleaned = url.strip().strip("/")
     if cleaned.count("/") >= 1:
         owner, repo = cleaned.split("/", 1)
-        return f"{owner}/{repo.split('/', 1)[0]}"
+        return f"{owner}/{_clean_repo(repo)}"
     raise ValueError(f"Cannot determine repository slug from: {url}")
 
 

--- a/axel/flywheel.py
+++ b/axel/flywheel.py
@@ -1,0 +1,113 @@
+"""Helpers for auditing repos against the flywheel CI template."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, List, Sequence
+from urllib.parse import urlparse
+
+import requests
+
+from .repo_manager import get_repo_file, load_repos
+
+REQUIRED_WORKFLOWS: tuple[str, ...] = (
+    "01-lint-format.yml",
+    "02-tests.yml",
+)
+_API_TIMEOUT = 10
+
+
+def _slug_from_url(url: str) -> str:
+    """Return ``owner/repo`` slug for ``url`` or raise ``ValueError``."""
+
+    parsed = urlparse(url)
+    if parsed.netloc:
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) >= 2:
+            return f"{parts[0]}/{parts[1]}"
+    cleaned = url.strip().strip("/")
+    if cleaned.count("/") >= 1:
+        owner, repo = cleaned.split("/", 1)
+        return f"{owner}/{repo.split('/', 1)[0]}"
+    raise ValueError(f"Cannot determine repository slug from: {url}")
+
+
+def _workflow_exists(slug: str, filename: str, token: str | None) -> bool:
+    """Return ``True`` when ``filename`` exists in the repo's workflow directory."""
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    url = f"https://api.github.com/repos/{slug}/contents/.github/workflows/{filename}"
+    response = requests.get(url, headers=headers, timeout=_API_TIMEOUT)
+    if response.status_code == 200:
+        return True
+    if response.status_code == 404:
+        return False
+    response.raise_for_status()
+    return False  # pragma: no cover - raise_for_status always raises here
+
+
+def evaluate_flywheel_alignment(
+    repos: Sequence[str], token: str | None = None
+) -> List[Dict[str, object]]:
+    """Return flywheel workflow coverage for each repository in ``repos``."""
+
+    results: List[Dict[str, object]] = []
+    for entry in repos:
+        try:
+            slug = _slug_from_url(entry)
+        except ValueError:
+            slug = entry.strip().strip("/") or entry
+        statuses: Dict[str, bool] = {}
+        for workflow in REQUIRED_WORKFLOWS:
+            statuses[workflow] = _workflow_exists(slug, workflow, token)
+        missing = [name for name, present in statuses.items() if not present]
+        results.append(
+            {
+                "repo": slug,
+                "workflows": statuses,
+                "missing": missing,
+                "aligned": not missing,
+            }
+        )
+    return results
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """CLI entry point for reporting flywheel workflow alignment."""
+
+    parser = argparse.ArgumentParser(
+        description="Check repos for flywheel workflow coverage",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=get_repo_file(),
+        help="Repository list (defaults to AXEL_REPO_FILE or repos.txt)",
+    )
+    parser.add_argument(
+        "--token",
+        default=None,
+        help="GitHub token for authenticated requests",
+    )
+    args = parser.parse_args(argv)
+
+    repos = load_repos(path=args.path)
+    if not repos:
+        print("No repositories to evaluate")
+        return
+
+    results = evaluate_flywheel_alignment(repos, token=args.token)
+    for result in results:
+        slug = str(result["repo"])
+        if result.get("aligned"):
+            print(f"{slug}: aligned")
+            continue
+        missing = ", ".join(result.get("missing", []))
+        print(f"{slug}: missing {missing}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI use only
+    main()

--- a/issues/0004-flywheel-template.md
+++ b/issues/0004-flywheel-template.md
@@ -4,4 +4,5 @@
 
 - [x] mention flywheel in README and AGENTS guidelines
 - [x] ensure repos.txt includes the flywheel repo
-- [ ] evaluate existing repos for alignment with flywheel's lint and test setup
+- [x] evaluate existing repos for alignment with flywheel's lint and test setup (use
+  `python -m axel.flywheel` with coverage in `tests/test_flywheel.py`)

--- a/tests/test_flywheel.py
+++ b/tests/test_flywheel.py
@@ -195,6 +195,14 @@ def test_slug_from_url_invalid() -> None:
         flywheel._slug_from_url("not-a-repo")
 
 
+def test_slug_from_url_strips_git_suffix() -> None:
+    assert (
+        flywheel._slug_from_url("https://github.com/example/project.git")
+        == "example/project"
+    )
+    assert flywheel._slug_from_url("example/project.git") == "example/project"
+
+
 def test_main_passes_token_to_evaluate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_flywheel.py
+++ b/tests/test_flywheel.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+import axel.flywheel as flywheel
+
+
+class DummyResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def make_responses(statuses: list[int]) -> Iterator[DummyResponse]:
+    for status in statuses:
+        yield DummyResponse(status)
+
+
+def test_evaluate_flywheel_alignment_reports_missing_workflows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    responses = make_responses([200, 404])
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: int) -> DummyResponse:
+        calls.append(url)
+        return next(responses)
+
+    monkeypatch.setattr(flywheel.requests, "get", fake_get)
+
+    repos = ["https://github.com/example/project"]
+    results = flywheel.evaluate_flywheel_alignment(repos)
+
+    assert results == [
+        {
+            "repo": "example/project",
+            "workflows": {
+                "01-lint-format.yml": True,
+                "02-tests.yml": False,
+            },
+            "missing": ["02-tests.yml"],
+            "aligned": False,
+        }
+    ]
+    assert len(calls) == 2
+
+
+def test_evaluate_handles_unparseable_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = make_responses([404, 404])
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: int) -> DummyResponse:
+        return next(responses)
+
+    monkeypatch.setattr(flywheel.requests, "get", fake_get)
+
+    results = flywheel.evaluate_flywheel_alignment(["example-project"])
+
+    assert results[0]["repo"] == "example-project"
+    assert results[0]["missing"] == [
+        "01-lint-format.yml",
+        "02-tests.yml",
+    ]
+
+
+def test_evaluate_includes_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[str | None] = []
+    responses = make_responses([200, 200])
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: int) -> DummyResponse:
+        captured.append(headers.get("Authorization"))
+        return next(responses)
+
+    monkeypatch.setattr(flywheel.requests, "get", fake_get)
+
+    flywheel.evaluate_flywheel_alignment(
+        ["https://github.com/example/project"], token="abc123"
+    )
+
+    assert captured == ["token abc123", "token abc123"]
+
+
+def test_main_prints_alignment_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo_file = tmp_path / "repos.txt"
+    repo_file.write_text("https://github.com/example/project\n", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    def fake_evaluate(repos: list[str], token: str | None = None):
+        captured["repos"] = repos
+        captured["token"] = token
+        return [
+            {
+                "repo": "example/project",
+                "workflows": {
+                    "01-lint-format.yml": True,
+                    "02-tests.yml": False,
+                },
+                "missing": ["02-tests.yml"],
+                "aligned": False,
+            }
+        ]
+
+    monkeypatch.setattr(flywheel, "evaluate_flywheel_alignment", fake_evaluate)
+
+    flywheel.main(["--path", str(repo_file)])
+
+    out = capsys.readouterr().out
+    assert "example/project" in out
+    assert "02-tests.yml" in out
+    assert captured["repos"] == ["https://github.com/example/project"]
+    assert captured["token"] is None
+
+
+def test_evaluate_accepts_slug_without_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = make_responses([200, 200])
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: int) -> DummyResponse:
+        return next(responses)
+
+    monkeypatch.setattr(flywheel.requests, "get", fake_get)
+
+    results = flywheel.evaluate_flywheel_alignment(["owner/project"])
+
+    assert results[0]["repo"] == "owner/project"
+
+
+def test_main_reports_aligned_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo_file = tmp_path / "repos.txt"
+    repo_file.write_text("https://github.com/example/project\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        flywheel,
+        "evaluate_flywheel_alignment",
+        lambda repos, token=None: [
+            {
+                "repo": "example/project",
+                "workflows": {
+                    "01-lint-format.yml": True,
+                    "02-tests.yml": True,
+                },
+                "missing": [],
+                "aligned": True,
+            }
+        ],
+    )
+
+    flywheel.main(["--path", str(repo_file)])
+
+    out = capsys.readouterr().out
+    assert "aligned" in out.lower()
+
+
+def test_main_handles_empty_repo_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo_file = tmp_path / "repos.txt"
+    repo_file.write_text("", encoding="utf-8")
+
+    flywheel.main(["--path", str(repo_file)])
+
+    assert "no repositories to evaluate" in capsys.readouterr().out.lower()
+
+
+def test_workflow_exists_raises_on_unexpected_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ErrorResponse(DummyResponse):
+        def raise_for_status(self) -> None:
+            raise RuntimeError("boom")
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: int) -> DummyResponse:
+        return ErrorResponse(500)
+
+    monkeypatch.setattr(flywheel.requests, "get", fake_get)
+
+    with pytest.raises(RuntimeError):
+        flywheel._workflow_exists(
+            "owner/repo",
+            "01-lint-format.yml",
+            None,
+        )
+
+
+def test_slug_from_url_invalid() -> None:
+    with pytest.raises(ValueError):
+        flywheel._slug_from_url("not-a-repo")
+
+
+def test_main_passes_token_to_evaluate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo_file = tmp_path / "repos.txt"
+    repo_file.write_text("https://github.com/example/project\n", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    def fake_evaluate(repos: list[str], token: str | None = None):
+        captured["token"] = token
+        return []
+
+    monkeypatch.setattr(flywheel, "evaluate_flywheel_alignment", fake_evaluate)
+
+    flywheel.main(["--path", str(repo_file), "--token", "secret-token"])
+
+    assert captured["token"] == "secret-token"


### PR DESCRIPTION
## Summary
- add an `axel.flywheel` helper that checks required flywheel workflows via the GitHub API and expose it through `python -m axel.flywheel`
- document the new command in the README and mark issue 0004’s checklist item complete with references to automated coverage
- create a focused test suite for the flywheel audit logic, covering URL parsing, token handling, CLI output, and error paths

## Testing
- `flake8 axel tests`
- `PYTHONPATH=. pytest --cov=axel --cov=tests`
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py` *(reports expected token-related keywords only)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f8470534832f81007aa4ff43b7a9