### PR TITLE
✨ : – add Discord capture search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,10 @@ strip_ansi(123)  # raises TypeError for invalid types
 ## discord bot
 
 See [docs/discord-bot.md](docs/discord-bot.md) for running a local Discord bot
-that saves mentioned messages to `local/discord/`.
+that saves mentioned messages to `local/discord/`. The bot exposes a `/axel search`
+slash command backed by `axel.discord_bot.search_captures` so you can locate saved
+notes without leaving Discord (see
+`tests/test_discord_bot.py::test_axel_search_command_replies_with_matches`).
 
 ## publishing
 

--- a/axel/discord_bot.py
+++ b/axel/discord_bot.py
@@ -92,9 +92,13 @@ def _matching_repo_urls(channel_name: str | None) -> list[str]:
 def _read_capture(path: Path, encrypter: Fernet | None) -> str | None:
     """Return the markdown contents for ``path`` handling encryption."""
 
-    try:
-        if encrypter is None:
+    if encrypter is None:
+        try:
             return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    try:
         data = path.read_bytes()
     except OSError:
         return None

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -27,6 +27,13 @@ already listed in `.gitignore`. The helper `axel.discord_bot.capture_message` do
 attachments before writing the markdown file, making it easy to exercise the behavior in
 tests.
 
+Use `axel.discord_bot.search_captures` to scan saved markdown files for matching text. The helper
+handles encrypted captures (when `AXEL_DISCORD_ENCRYPTION_KEY` is set) and limits the number of
+results returned; see
+`tests/test_discord_bot.py::test_search_captures_returns_matches`,
+`tests/test_discord_bot.py::test_search_captures_decrypts_encrypted_files`, and
+`tests/test_discord_bot.py::test_search_captures_respects_limit`.
+
 ## Encrypting Captures
 
 Set `AXEL_DISCORD_ENCRYPTION_KEY` to a
@@ -72,6 +79,13 @@ once decrypted.
 - **Attachments** – saved to `local/discord/<channel>/<message_id>/` with references inside the
   markdown (see `tests/test_discord_bot.py::test_capture_message_downloads_attachments`).
 
+## Slash Commands
+
+The bot registers `/axel search` as a slash command for quickly locating saved captures by
+keyword. Results list relative file paths and the first matching line, returned as an
+ephemeral response so only the requester sees the output. Coverage lives in
+`tests/test_discord_bot.py::test_axel_search_command_replies_with_matches`.
+
 ## Analyzing Captured Messages
 
 Saved files can be processed with local LLMs such as
@@ -95,8 +109,9 @@ Automated coverage for the capture format lives in
 
 Future improvements will expand the bot's capabilities:
 
-- **Command interface** – provide slash commands such as `/axel summarize`
-  or `/axel search` that run the local LLM on stored messages.
+- **Command interface** – extend the existing `/axel search` command with
+  additional actions such as `/axel summarize` that run local LLM workflows on
+  stored messages.
 
 Contributions and ideas are welcome. Keep all bot logic local and respect user privacy.
 Automated coverage lives in `tests/test_discord_bot.py` (see the tests referenced above).

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -48,6 +48,44 @@ def read_markdown(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def test_read_capture_returns_none_when_plaintext_unavailable(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.md"
+
+    assert db._read_capture(missing_path, None) is None
+
+
+def test_read_capture_returns_none_when_encrypted_file_missing(tmp_path: Path) -> None:
+    class DummyEncrypter:
+        def decrypt(self, data: bytes) -> bytes:  # pragma: no cover - defensive
+            raise AssertionError("decrypt should not be called")
+
+    missing_path = tmp_path / "missing.md"
+
+    assert db._read_capture(missing_path, DummyEncrypter()) is None
+
+
+def test_read_capture_returns_none_when_decryption_fails(tmp_path: Path) -> None:
+    encrypted_path = tmp_path / "encrypted.md"
+    encrypted_path.write_bytes(b"payload")
+
+    class DummyEncrypter:
+        def decrypt(self, data: bytes) -> bytes:
+            raise ValueError("cannot decrypt")
+
+    assert db._read_capture(encrypted_path, DummyEncrypter()) is None
+
+
+def test_read_capture_decodes_with_ignore_when_utf8_invalid(tmp_path: Path) -> None:
+    encrypted_path = tmp_path / "encrypted.md"
+    encrypted_path.write_bytes(b"payload")
+
+    class DummyEncrypter:
+        def decrypt(self, data: bytes) -> bytes:
+            return b"\xff\xfe"
+
+    assert db._read_capture(encrypted_path, DummyEncrypter()) == ""
+
+
 def test_save_message_includes_context(tmp_path: Path) -> None:
     """Thread or reply context is recorded alongside the saved message."""
 
@@ -337,6 +375,40 @@ def test_save_message_without_channel(tmp_path: Path) -> None:
     assert "direct-message" in content
 
 
+def test_search_captures_returns_empty_when_limit_non_positive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AXEL_DISCORD_DIR", str(tmp_path))
+
+    assert db.search_captures("anything", limit=0) == []
+    assert db.search_captures("anything", limit=-1) == []
+
+
+def test_search_captures_returns_empty_when_directory_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing = tmp_path / "missing"
+    monkeypatch.setenv("AXEL_DISCORD_DIR", str(missing))
+
+    assert db.search_captures("anything") == []
+
+
+def test_search_captures_truncates_long_snippets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AXEL_DISCORD_DIR", str(tmp_path))
+    capture_dir = tmp_path / "channel"
+    capture_dir.mkdir()
+    capture_path = capture_dir / "note.md"
+    capture_path.write_text("A" * 130)
+
+    results = db.search_captures("A")
+
+    assert results
+    assert len(results[0].snippet) == 120
+    assert results[0].snippet.endswith("...")
+
+
 def test_search_captures_returns_matches(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -399,6 +471,58 @@ def test_search_captures_respects_limit(
     results = db.search_captures("match", limit=2)
 
     assert len(results) == 2
+
+
+def test_search_command_sends_no_results_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    intents = discord.Intents.none()
+    client = db.AxelClient(intents=intents)
+    command = client.tree.get_command("axel").get_command("search")
+
+    class DummyResponse:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, bool]] = []
+
+        async def send_message(self, content: str, *, ephemeral: bool) -> None:
+            self.calls.append((content, ephemeral))
+
+    interaction = SimpleNamespace(response=DummyResponse())
+    monkeypatch.setattr(db, "search_captures", lambda query: [])
+
+    asyncio.run(command.callback(interaction, "query"))
+
+    assert interaction.response.calls == [("No captures found for 'query'.", True)]
+
+
+def test_search_command_handles_non_relative_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    intents = discord.Intents.none()
+    client = db.AxelClient(intents=intents)
+    command = client.tree.get_command("axel").get_command("search")
+
+    result_path = tmp_path / "outside" / "note.md"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text("match line")
+
+    monkeypatch.setattr(db, "search_captures", lambda query: [db.SearchResult(result_path, "match line")])
+    monkeypatch.setattr(db, "_get_save_dir", lambda: tmp_path / "root")
+
+    class DummyResponse:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, bool]] = []
+
+        async def send_message(self, content: str, *, ephemeral: bool) -> None:
+            self.calls.append((content, ephemeral))
+
+    interaction = SimpleNamespace(response=DummyResponse())
+
+    asyncio.run(command.callback(interaction, "query"))
+
+    assert interaction.response.calls
+    message, ephemeral = interaction.response.calls[0]
+    assert ephemeral is True
+    assert "outside/note.md" in message
+    assert "match line" in message
 
 
 def test_capture_message_downloads_attachments(tmp_path: Path) -> None:

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -54,6 +54,13 @@ def test_read_capture_returns_none_when_plaintext_unavailable(tmp_path: Path) ->
     assert db._read_capture(missing_path, None) is None
 
 
+def test_read_capture_returns_none_when_plaintext_decode_fails(tmp_path: Path) -> None:
+    broken_path = tmp_path / "broken.md"
+    broken_path.write_bytes(b"\xff\xfe")
+
+    assert db._read_capture(broken_path, None) is None
+
+
 def test_read_capture_returns_none_when_encrypted_file_missing(tmp_path: Path) -> None:
     class DummyEncrypter:
         def decrypt(self, data: bytes) -> bytes:  # pragma: no cover - defensive
@@ -473,7 +480,9 @@ def test_search_captures_respects_limit(
     assert len(results) == 2
 
 
-def test_search_command_sends_no_results_message(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_search_command_sends_no_results_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     intents = discord.Intents.none()
     client = db.AxelClient(intents=intents)
     command = client.tree.get_command("axel").get_command("search")
@@ -504,7 +513,11 @@ def test_search_command_handles_non_relative_paths(
     result_path.parent.mkdir(parents=True)
     result_path.write_text("match line")
 
-    monkeypatch.setattr(db, "search_captures", lambda query: [db.SearchResult(result_path, "match line")])
+    monkeypatch.setattr(
+        db,
+        "search_captures",
+        lambda query: [db.SearchResult(result_path, "match line")],
+    )
     monkeypatch.setattr(db, "_get_save_dir", lambda: tmp_path / "root")
 
     class DummyResponse:

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -368,6 +368,21 @@ def test_search_captures_decrypts_encrypted_files(
     assert results[0].path == tmp_path / "secure" / "11.md"
 
 
+def test_search_captures_skips_encrypted_when_key_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AXEL_DISCORD_DIR", str(tmp_path))
+
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+    encrypted_path = secure_dir / "20.md"
+    encrypted_path.write_bytes(b"\xff\xfe\xfd\x00")
+
+    results = db.search_captures("secret")
+
+    assert results == []
+
+
 def test_search_captures_respects_limit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
what: add capture search helper, slash command, docs, and tests
why: ship promised Discord bot command for local capture discovery
how to test:
  flake8 axel tests
  pytest --cov=axel --cov=tests
  pre-commit run --all-files
  git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e3f8470534832f81007aa4ff43b7a9