### PR TITLE
✅ Mark quest roadmap integration as complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This launches the token.place server, relay and a mock LLM using one command.
 - [x] contributor guide (see `CONTRIBUTING.md`)
 - [x] remove repos from the list (`python -m axel.repo_manager remove`)
 - [x] fetch repos from the GitHub API (`python -m axel.repo_manager fetch`)
-- [ ] integrate LLM assistants to suggest quests across repos
+- [x] integrate LLM assistants to suggest quests across repos
 - [ ] integrate `token.place` clients across all repos
 - [ ] integrate [`gabriel`](https://github.com/futuroptimist/gabriel) as a security layer across repos
 - [x] self-hosted Discord bot for ingesting messages when mentioned (see docs/discord-bot.md)
@@ -92,6 +92,8 @@ module powers the "suggest quests" promise described in the roadmap and is cover
 Quests that involve token.place automatically reference `gabriel` to reinforce the
 security layer described in `issues/0003-gabriel-security-layer.md`; see
 `tests/test_quests.py::test_suggest_cross_repo_quests_mentions_gabriel_for_sensitive_pairs`.
+The roadmap entry for this integration stays checked via
+`tests/test_readme.py::test_readme_marks_llm_quests_complete`.
 11. Clear all tasks with `python -m axel.task_manager clear`.
 12. Pass `--path <file>` or set `AXEL_TASK_FILE` to use a custom task list. The task CLI also
     accepts `--path` before or after the subcommand (see
@@ -115,6 +117,8 @@ module powers the "suggest quests" promise described in the roadmap and is cover
 Quests that involve token.place automatically reference `gabriel` to reinforce the
 security layer described in `issues/0003-gabriel-security-layer.md`; see
 `tests/test_quests.py::test_suggest_cross_repo_quests_mentions_gabriel_for_sensitive_pairs`.
+The roadmap entry for this integration stays checked via
+`tests/test_readme.py::test_readme_marks_llm_quests_complete`.
 
 ## local setup
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_readme_marks_llm_quests_complete() -> None:
+    """The roadmap should reflect the shipped cross-repo quest helper."""
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text(encoding="utf-8")
+
+    assert "- [x] integrate LLM assistants to suggest quests across repos" in content


### PR DESCRIPTION
## Summary
- add a regression test that ensures the README roadmap keeps the LLM quest helper marked complete
- update the roadmap checkbox and reference the new coverage in the quests section

## Testing
- flake8 axel tests
- pytest --cov=axel --cov=tests
- pre-commit run --all-files
- git diff --cached | ./scripts/scan-secrets.py *(flagged existing token.place references only)*

------
https://chatgpt.com/codex/tasks/task_e_68e55c0b6574832f857e41de389ab689