### PR TITLE
✨ Include thread repo metadata in Discord captures

### DIFF
--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -67,8 +67,8 @@ once decrypted.
     the author, timestamp, source link, and an indented line with the original message text
     (or `(no content)` when empty).
    - the captured message content beneath the metadata and context
-4. If the channel name matches a repository listed in the project's repo list
-   (`repos.txt` or a file pointed to by `AXEL_REPO_FILE`), the saved metadata
+4. If the channel or thread name matches a repository listed in the project's repo
+   list (`repos.txt` or a file pointed to by `AXEL_REPO_FILE`), the saved metadata
    includes a `Repository:` entry pointing to the matching URL so you can treat the
    capture as project knowledge for that repo.
 
@@ -103,6 +103,7 @@ summarize discussions, extract tasks, or generate project insights.
 Automated coverage for the capture format lives in
 `tests/test_discord_bot.py::test_save_message_includes_metadata`,
 `tests/test_discord_bot.py::test_save_message_includes_repository_metadata`,
+`tests/test_discord_bot.py::test_save_message_includes_repository_metadata_from_thread`,
 `tests/test_discord_bot.py::test_save_message_records_thread_metadata`,
 `tests/test_discord_bot.py::test_save_message_includes_context`,
 `tests/test_discord_bot.py::test_save_message_orders_context_oldest_first`,

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -349,6 +349,28 @@ def test_save_message_includes_repository_metadata(tmp_path: Path, monkeypatch) 
     assert "- Repository: https://github.com/example/project.one" in content
 
 
+def test_save_message_includes_repository_metadata_from_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Thread names matching repos also add repository metadata."""
+
+    repo_file = tmp_path / "repos.txt"
+    repo_file.write_text("https://github.com/example/feature-chat\n", encoding="utf-8")
+    monkeypatch.setenv("AXEL_REPO_FILE", str(repo_file))
+
+    db.SAVE_DIR = tmp_path
+    parent = DummyChannel("projects")
+    thread = DummyChannel("feature-chat", parent=parent)
+    msg = DummyMessage("thread insight", channel=thread)
+
+    path = db.save_message(msg)
+
+    assert path == tmp_path / "projects" / "1.md"
+    content = read_markdown(path)
+    assert "- Thread: feature-chat" in content
+    assert "- Repository: https://github.com/example/feature-chat" in content
+
+
 def test_save_message_with_blank_channel_skips_repository_lookup(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- teach `axel.discord_bot._matching_repo_urls` to look at both channel and thread names so Discord captures keep repository metadata even when the thread title matches the repo
- add a regression test exercising thread-aware matching and update the Discord bot guide with the new coverage reference

## Testing
- uv run flake8 axel tests
- pytest --cov=axel --cov=tests
- uv run pre-commit run --all-files
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e55c0b6574832f857e41de389ab689