### PR TITLE
Handle legacy task listings without completion flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ security layer described in `issues/0003-gabriel-security-layer.md`; see
     accepts `--path` before or after the subcommand (see
     `tests/test_task_manager.py::test_main_add_accepts_path_after_subcommand`).
 13. Empty, invalid, or non-list `tasks.json` files are treated as containing no tasks.
-14. Set `AXEL_DISCORD_ENCRYPTION_KEY` to a Fernet key to encrypt Discord captures on disk.
-15. Audit repositories for flywheel workflow coverage with `python -m axel.flywheel --path repos.txt`.
+14. Legacy task entries missing the `completed` field default to pending output (see
+    `tests/test_task_manager.py::test_main_list_handles_missing_completed_field`).
+15. Set `AXEL_DISCORD_ENCRYPTION_KEY` to a Fernet key to encrypt Discord captures on disk.
+16. Audit repositories for flywheel workflow coverage with `python -m axel.flywheel --path repos.txt`.
     The command reports missing workflows (lint/tests) so you can align each project with the
     flywheel template. Automated coverage lives in
     `tests/test_flywheel.py::test_evaluate_flywheel_alignment_reports_missing_workflows` and

--- a/axel/task_manager.py
+++ b/axel/task_manager.py
@@ -174,8 +174,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     else:
         tasks = list_tasks(path=args.path)
     for task in tasks:
-        status = "[x]" if task["completed"] else "[ ]"
-        print(f"{task['id']} {status} {task['description']}")
+        completed = bool(task.get("completed"))
+        status = "[x]" if completed else "[ ]"
+        task_id = task.get("id", "?")
+        description = task.get("description", "")
+        print(f"{task_id} {status} {description}")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual use

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -427,6 +427,21 @@ def test_main_branches(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> No
     assert tm.list_tasks(path=file) == []
 
 
+def test_main_list_handles_missing_completed_field(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Legacy task entries without ``completed`` default to pending in output."""
+
+    file = tmp_path / "tasks.json"
+    file.write_text(json.dumps([{"id": 1, "description": "legacy task"}]))
+
+    from axel import task_manager as tm
+
+    tm.main(["--path", str(file), "list"])
+    output = capsys.readouterr().out
+    assert "1 [ ] legacy task" in output
+
+
 def test_clear_tasks(tmp_path: Path) -> None:
     file = tmp_path / "tasks.json"
     add_task("write docs", path=file)


### PR DESCRIPTION
## Summary
- default missing `completed` fields to pending when listing tasks so legacy data no longer crashes the CLI
- add regression coverage for the legacy JSON scenario and document the behavior in the README

## Testing
- flake8 axel tests
- pytest --cov=axel --cov=tests
- pre-commit run --all-files
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e55c0b6574832f857e41de389ab689