### PR TITLE
✨ : include bullet lines in Discord summaries

### DIFF
--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -90,7 +90,8 @@ Use `/axel summarize` to generate a quick synopsis of the first capture that mat
 provided query. The helper prioritizes the saved message body, skipping metadata and
 thread context so the summary stays focused on the actionable text. Summaries surface the
 relative file path alongside the condensed content in an ephemeral response. Coverage
-spans `tests/test_discord_bot.py::test_summarize_capture_extracts_message_body` and
+spans `tests/test_discord_bot.py::test_summarize_capture_extracts_message_body`,
+`tests/test_discord_bot.py::test_summarize_capture_includes_bullet_message_body`, and
 `tests/test_discord_bot.py::test_axel_summarize_command_replies_with_summary`.
 
 ## Analyzing Captured Messages

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -126,6 +126,32 @@ def test_summarize_capture_extracts_message_body(tmp_path: Path) -> None:
     assert "Channel" not in summary  # metadata lines are skipped
 
 
+def test_summarize_capture_includes_bullet_message_body(tmp_path: Path) -> None:
+    capture = tmp_path / "general" / "bullet.md"
+    capture.parent.mkdir(parents=True, exist_ok=True)
+    capture.write_text(
+        "\n".join(
+            [
+                "# user",
+                "",
+                "- Channel: general",
+                "- Timestamp: 2024-01-01T00:00:00+00:00",
+                "",
+                "- First actionable bullet",
+                "- Second actionable bullet",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = db.summarize_capture(capture)
+
+    assert summary is not None
+    assert "First actionable bullet" in summary
+    assert "Second actionable bullet" in summary
+    assert "Channel" not in summary
+
+
 def test_summarize_capture_uses_first_line_when_body_missing(tmp_path: Path) -> None:
     capture = tmp_path / "random" / "2.md"
     capture.parent.mkdir(parents=True)


### PR DESCRIPTION
what: ensure Discord summaries keep bullet-only messages
why: docs promise message body prioritization even for bullet lists
how to test: flake8 axel tests
how to test: pytest --cov=axel --cov=tests
how to test: pre-commit run --all-files
how to test: git diff --cached | ./scripts/scan-secrets.py
Refs: #0005

------
https://chatgpt.com/codex/tasks/task_e_68e55c0b6574832f857e41de389ab689